### PR TITLE
make geometry reads agnostic of the delimiters used

### DIFF
--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -42,7 +42,9 @@ def extract_ase_data(a, atoms):
     '''
     symbols = []
     positions = []
-    lattice_vectors = np.genfromtxt(StringIO(a),delimiter=',',dtype=np.float64)
+    lattice_vectors = np.genfromtxt(
+        StringIO(a.replace(',', ' ')), dtype=np.float64
+    )
     for atom in atoms.splitlines():
         if len(atom) == 0 or len(atom.split()) != 4:
             continue


### PR DESCRIPTION
Allows for agnostic behavior with respect to the choice of delimiters (comma, spaces, tabs, etc.) in the geometry file. This should address #14 