### PR TITLE
[FIX] update get_veff() in pyscf_init.py

### DIFF
--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -117,7 +117,7 @@ class pyscf_pbc_init (pyscf_init):
         if self.args.xc is not None:
             vhf = mf.get_veff().astype(dtype=np.complex128)
         else:
-            vhf = mf.get_veff(dm=hf_dm).astype(dtype=np.complex128)
+            vhf = mf.get_veff(hf_dm).astype(dtype=np.complex128)
         F = mf.get_fock(T,S,vhf,hf_dm).astype(dtype=np.complex128)
     
         if len(F.shape) == 3:

--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -117,7 +117,7 @@ class pyscf_pbc_init (pyscf_init):
         if self.args.xc is not None:
             vhf = mf.get_veff().astype(dtype=np.complex128)
         else:
-            vhf = mf.get_veff(hf_dm).astype(dtype=np.complex128)
+            vhf = mf.get_veff(dm=hf_dm).astype(dtype=np.complex128)
         F = mf.get_fock(T,S,vhf,hf_dm).astype(dtype=np.complex128)
     
         if len(F.shape) == 3:
@@ -323,7 +323,7 @@ class pyscf_mol_init (pyscf_init):
         if self.args.xc is not None:
             vhf = mf.get_veff().astype(dtype=np.complex128)
         else:
-            vhf = mf.get_veff(hf_dm).astype(dtype=np.complex128)
+            vhf = mf.get_veff(dm=hf_dm).astype(dtype=np.complex128)
         F = mf.get_fock(T,S,vhf,hf_dm).astype(dtype=np.complex128)
 
 


### PR DESCRIPTION
### Fixes:
- Always forwards the density matrix correctly to get_veff under `pyscf_mol_init()`
- Resolves issue #18.