### PR TITLE
add support for variable nkx, nky, nkz

### DIFF
--- a/examples/useful_scripts/nvnl_winter_analysis.py
+++ b/examples/useful_scripts/nvnl_winter_analysis.py
@@ -72,7 +72,8 @@ def main():
     bz2ibz = f["/symmetry/k/bz2ibz"][()]
     tr_conj = f["/symmetry/k/tr_conj"][()]
     k_sym_trans = f["/symmetry/k/k_sym_transform_ao"][()]
-    Sk = f['HF/S-k'][()]
+    Sk = f['HF/S-k'][()].view(complex)
+    Sk = Sk.reshape(Sk.shape[:-1])
     Hk = f['HF/H-k'][()].view(complex)
     Hk = Hk.reshape(Hk.shape[:-1])
     f.close()
@@ -147,7 +148,7 @@ def main():
             Fk, kmesh_scaled, band_kpts, dim=3, hermi=True
         )
         Sigma_tk_int = winter.interpolate_tk_object(
-            Sigma_tk, kmesh_scaled, band_kpts, dim=3, hermi=True
+            Sigma_tk, kmesh_scaled, band_kpts, dim=3, hermi=False
         )
         # form G_tk by solving dyson
         print('Number of iw: ', mbo.ir.wsample.shape[0])

--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -440,7 +440,7 @@ def add_pbc_params(parser):
     Define PBC-specific command line arguments for Green python module
     '''
     parser.add_argument("--a", type=parse_geometry, help="lattice geometry", required=True)
-    parser.add_argument("--nk", type=int, help="number of k-points in each direction", required=True)
+    parser.add_argument("--nk", type=int, nargs='+', help="number of k-points in each direction. Provide 1 value for symmetric mesh or 3 values for anisotropic mesh.", required=True)
     parser.add_argument("--pseudo", type=str, nargs="*", default=[None], help="pseudopotential")
     parser.add_argument("--shift", type=float, nargs=3, default=[0.0, 0.0, 0.0], help="mesh shift")
     parser.add_argument("--center", type=float, nargs=3, default=[0.0, 0.0, 0.0], help="mesh center")
@@ -479,7 +479,7 @@ def init_mol_params(params=None):
     args.ns = 1 if args.restricted or args.x2c == 2 else 2
     # parameters needed to create empty grid
     args.a = [[1,0,0],[0,1,0],[0,0,1]]
-    args.nk = 1
+    args.nk = [1, 1, 1]
     args.shift =  [0.,0.,0.]
     args.center = [0.,0.,0.]
     return args
@@ -493,6 +493,10 @@ def init_pbc_params(params=None):
     add_common_params(parser)
     add_pbc_params(parser)
     args = parser.parse_args(args=params)
+    if len(args.nk) == 1:
+        args.nk = [args.nk[0], args.nk[0], args.nk[0]]
+    elif len(args.nk) != 3:
+        raise ValueError("--nk must be given 1 or 3 integers, got {}".format(len(args.nk)))
     args.basis = parse_basis(args.basis)
     args.auxbasis = parse_basis(args.auxbasis)
     args.ecp = parse_basis(args.ecp)
@@ -601,13 +605,13 @@ def init_k_mesh(args, mycell):
        args.shift = [0,0,0]
     if args.x2c < 2:
         # for normal and sfX2C1e calculations
-        kstruct = mycell.make_kpts([args.nk, args.nk, args.nk], scaled_center=args.center,
+        kstruct = mycell.make_kpts(args.nk, scaled_center=args.center,
                                space_group_symmetry=args.space_symm, time_reversal_symmetry=args.tr_symm)
     else:
         # for X2C1e calculations
         print("X2C1e calculations do not support space group symmetry. Only time-reversal symmetry is used.")
         print("Double group symmetry will be implemented in future releases.")
-        kstruct = mycell.make_kpts([args.nk, args.nk, args.nk], scaled_center=args.center,
+        kstruct = mycell.make_kpts(args.nk, scaled_center=args.center,
                                space_group_symmetry=False, time_reversal_symmetry=args.tr_symm)
 
     if not (args.space_symm or args.tr_symm):
@@ -672,10 +676,8 @@ def init_q_mesh(args, mycell, k_mesh, save_data=True):
     tr_symm = bool(getattr(args, "tr_symm", True))
     space_symm = bool(getattr(args, "space_symm", True))
 
-    if args.x2c < 2:
-        qstruct = kpt_utils.build_q_struct(mycell, k_mesh, space_symm=space_symm, tr_symm=tr_symm)
-    else:
-        qstruct = kpt_utils.build_q_struct(mycell, k_mesh, space_symm=False, tr_symm=tr_symm)
+    # Unlike k-mesh, the presence or absence of relativity doesn't concern q_mesh structure
+    qstruct = kpt_utils.build_q_struct(mycell, k_mesh, space_symm=space_symm, tr_symm=tr_symm)
 
     # Obtain all info to save
     nq = qstruct.nkpts

--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -469,7 +469,7 @@ def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5")
     df1._cderi = cderi_file_1
     df1.kpts = kmesh
     df1.build()
-    nk1, nk2, nk3 = args.nk
+    _, nk2, nk3 = args.nk
 
     # We know that G=0 contribution diverge only when q = 0
     # so we loop over (k1,k1) pairs
@@ -509,13 +509,8 @@ def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5")
             buffer2[s1:s1+Lpq.shape[0], :, :] = Lpq_mo[0:Lpq.shape[0],:,:]
             s1 += Lpq.shape[0]
 
-        # i = k1 * nk2 * nk3 + k2 * nk3 + k3
-        k3 = int(i / (nk2 * nk3))
-        k2 = int((i % (nk2 * nk3)) / nk3)
-        k1 = int(i % nk3)
-        k_fine = k3 * nk2 * nk3 + k2 * nk3 + k1
-        EW["{}".format(k_fine)] = (buffer1 - buffer2).view(np.float64)
-        EW_bar["{}".format(k_fine)] = buffer2.view(np.float64)
+        EW["{}".format(i)] = (buffer1 - buffer2).view(np.float64)
+        EW_bar["{}".format(i)] = buffer2.view(np.float64)
         buffer1[:] = 0.0
         buffer2[:] = 0.0
 

--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -469,7 +469,7 @@ def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5")
     df1._cderi = cderi_file_1
     df1.kpts = kmesh
     df1.build()
-    nk = args.nk
+    nk1, nk2, nk3 = args.nk
 
     # We know that G=0 contribution diverge only when q = 0
     # so we loop over (k1,k1) pairs
@@ -509,11 +509,11 @@ def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5")
             buffer2[s1:s1+Lpq.shape[0], :, :] = Lpq_mo[0:Lpq.shape[0],:,:]
             s1 += Lpq.shape[0]
 
-        # i = k1 * nk * nk + k2 * nk + k3
-        k3 = int(i /(nk*nk))
-        k2 = int((i % (nk*nk))/nk)
-        k1 = int(i % nk)
-        k_fine = (k3) * (nk)*(nk) + (k2) * (nk) + (k1)
+        # i = k1 * nk2 * nk3 + k2 * nk3 + k3
+        k3 = int(i / (nk2 * nk3))
+        k2 = int((i % (nk2 * nk3)) / nk3)
+        k1 = int(i % nk3)
+        k_fine = k3 * nk2 * nk3 + k2 * nk3 + k1
         EW["{}".format(k_fine)] = (buffer1 - buffer2).view(np.float64)
         EW_bar["{}".format(k_fine)] = buffer2.view(np.float64)
         buffer1[:] = 0.0

--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -89,7 +89,7 @@ class pyscf_pbc_init (pyscf_init):
             mydf._cderi_to_save = "cderi.h5"
             mydf.build()
         # number of k-points in each direction for Coulomb integrals
-        nk       = self.args.nk ** 3
+        nk       = np.prod(self.args.nk)
         # number of k-points in each direction to evaluate Coulomb kernel
         Nk       = self.args.Nk
 
@@ -223,7 +223,7 @@ class pyscf_pbc_init (pyscf_init):
         logging.debug(kmesh_hs)
         logging.debug(self.cell.get_scaled_kpts(kmesh_hs))
         inp_data["high_symm_path/k_mesh"] = self.cell.get_scaled_kpts(kmesh_hs)
-        inp_data["high_symm_path/r_mesh"] = ft.construct_rmesh(self.args.nk, self.args.nk, self.args.nk)
+        inp_data["high_symm_path/r_mesh"] = ft.construct_rmesh(*self.args.nk)
         inp_data["high_symm_path/Hk"] = Hk_hs
         inp_data["high_symm_path/Sk"] = Sk_hs
         inp_data["high_symm_path/xpath"] = xpath
@@ -320,7 +320,7 @@ class pyscf_mol_init (pyscf_init):
 #comm.construct_gdf(self.args, self.cell, self.kmesh)
 
         # number of k-points in each direction for Coulomb integrals
-        nk       = self.args.nk ** 3
+        nk       = np.prod(self.args.nk)
         # number of k-points in each direction to evaluate Coulomb kernel
         Nk       = self.args.Nk
 
@@ -355,10 +355,11 @@ class pyscf_mol_init (pyscf_init):
         F = mf.get_fock(T,S,vhf,hf_dm).astype(dtype=np.complex128)
 
 
-        F = F.reshape((self.args.ns, self.args.nk, nso, nso))
-        hf_dm = hf_dm.reshape((self.args.ns, self.args.nk, nso, nso))
-        S = S.reshape((self.args.nk, nso, nso))
-        T = T.reshape((self.args.nk, nso, nso))
+        nk_tot = np.prod(self.args.nk)
+        F = F.reshape((self.args.ns, nk_tot, nso, nso))
+        hf_dm = hf_dm.reshape((self.args.ns, nk_tot, nso, nso))
+        S = S.reshape((nk_tot, nso, nso))
+        T = T.reshape((nk_tot, nso, nso))
     
         if len(F.shape) == 3:
             F     = F.reshape((1,) + F.shape)

--- a/tests/pyscf_pbc_init_test.py
+++ b/tests/pyscf_pbc_init_test.py
@@ -135,3 +135,16 @@ def test_anisotropic_nk_matches_symmetric(data_path) -> None:
     finally:
         os.chdir(old_cwd)
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize("bad_nk", [["2", "3"], ["1", "2", "3", "4"]])
+def test_invalid_nk_count_raises(bad_nk) -> None:
+    """Providing 2 or 4 values to --nk must raise a ValueError."""
+    params = [
+        "--atom", "H 0 0 0",
+        "--a", "5 0 0, 0 5 0, 0 0 5",
+        "--basis", "sto-3g",
+        "--nk", *bad_nk,
+    ]
+    with pytest.raises(ValueError, match="--nk must be given 1 or 3 integers"):
+        comm.init_pbc_params(params=params)

--- a/tests/pyscf_pbc_init_test.py
+++ b/tests/pyscf_pbc_init_test.py
@@ -90,3 +90,48 @@ def test_meanfield_variants(data_path, extra_flags, subdir) -> None:
         # clean up immediately
         os.chdir(old_cwd)
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def test_anisotropic_nk_matches_symmetric(data_path) -> None:
+    """Verify that --nk 3 3 3 produces the same result as --nk 3."""
+    import os
+
+    test_data_dir = Path(pytest.test_data_dir) / "H2_pbc"
+    tmp_dir = Path(__file__).parent / "tmp"
+
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir()
+    old_cwd = Path.cwd()
+    os.chdir(tmp_dir)
+    output_h5 = tmp_dir / "input.h5"
+
+    try:
+        params = [
+            "--atom", "H -0.25 -0.25 -0.25\nH  0.25  0.25  0.25",
+            "--a", "4.0655, 0.0,    0.0\n0.0,    4.0655, 0.0\n0.0,    0.0,    4.0655\n",
+            "--output_path", str(output_h5),
+            "--df_int", "0",
+            "--nk", "3", "3", "3",
+            "--basis", "gth-dzvp-molopt-sr",
+            "--pseudo", "gth-pbe",
+            "--use_j2c_eig_decomposition", "false",
+        ]
+
+        args = comm.init_pbc_params(params=params)
+        pyscf_init = pymb.pyscf_pbc_init(args)
+        pyscf_init.mean_field_input()
+
+        expected_h5 = test_data_dir / "UHF" / "input.h5"
+        datasets = [
+            "HF/Energy",
+            "HF/Energy_nuc",
+            "HF/Fock-k",
+            "HF/S-k",
+            "HF/H-k",
+            "HF/mo_energy",
+        ]
+        compare_datasets(output_h5, expected_h5, datasets)
+    finally:
+        os.chdir(old_cwd)
+        shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
In existing code, we assume a symmetric k-mesh with the form (nk, nk, nk) all specified by command line argument `--nk X`.
This update generalizes this behavior, allowing for two kinds of inputs:
* `--nk X` will create a symmetric `[X, X, X]` k-mesh;
* `--nk X Y Z` will create a general `[X, Y, Z]` k-mesh;
* other number of inputs for `--nk` will throw an error.

Another key update is for the bosonic q-mesh:
* Old: if `x2c=True`, then drop all space group symmetry simplification for k-mesh and q-mesh;
* New: while k-mesh will require further implementation of double groups, polarization and other bosonic quantities can still be simplified to live on symmetry-reduced q-mesh.
This will result in MASSIVE reduction in the first part of GW loops, where we construct P0 and invert it for each q-point.