### PR TITLE
Reduce threshold for hermitian checks on J2C integrals

### DIFF
--- a/examples/useful_scripts/wannier_fock.py
+++ b/examples/useful_scripts/wannier_fock.py
@@ -57,11 +57,11 @@ x2c = args.x2c
 print("Reading input file")
 f = h5py.File(input_path, 'r')
 cell = f["Cell"][()]
-kmesh_abs = f["/grid/k_mesh"][()]
-kmesh_scaled = f["/grid/k_mesh_scaled"][()]
-index = f["/grid/index"][()]
-ir_list = f["/grid/ir_list"][()]
-conj_list = f["/grid/conj_list"][()]
+kmesh_abs = f["/symmetry/k/mesh"][()]
+kmesh_scaled = f["/symmetry/k/mesh_scaled"][()]
+index = f["/symmetry/k/bz2ibz"][()]
+ir_list = f["/symmetry/k/ibz2bz"][()]
+conj_list = f["/symmetry/k/tr_conj"][()]
 Fk = f["HF/Fock-k"][()].view(complex)
 Fk = Fk.reshape(Fk.shape[:-1])
 nk = index.shape[0]

--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -979,7 +979,10 @@ def store_auxcell_kstruct_ops_info(args, auxcell, kmesh):
     j2c_sqrt_irre = []
     for irre_q in irre_q_inds:
         j2c_i = j2c_data[f'j2c/{irre_q}'][...]
-        assert np.all(j2c_i - j2c_i.conj().T < 1e-12), "j2c metric is not Hermitian"
+        j2c_i_dagger = j2c_i.conj().T
+        assert np.all(j2c_i - j2c_i_dagger < 1e-10), "j2c metric is not Hermitian"
+        # make it explicitly hermitian
+        j2c_i = (j2c_i + j2c_i_dagger) / 2
         if j2c_decomp == 'cholesky':
             j2c_sqrt_i, _ = int_utils.cholesky_decomposed_metric(j2c_i, auxcell, inv=False)
         elif j2c_decomp == 'eigenvalue':

--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -980,7 +980,7 @@ def store_auxcell_kstruct_ops_info(args, auxcell, kmesh):
     for irre_q in irre_q_inds:
         j2c_i = j2c_data[f'j2c/{irre_q}'][...]
         j2c_i_dagger = j2c_i.conj().T
-        assert np.all(j2c_i - j2c_i_dagger < 1e-10), "j2c metric is not Hermitian"
+        assert np.allclose(j2c_i, j2c_i_dagger, atol=1e-10, rtol=0), "j2c metric is not Hermitian"
         # make it explicitly hermitian
         j2c_i = (j2c_i + j2c_i_dagger) / 2
         if j2c_decomp == 'cholesky':


### PR DESCRIPTION
The PR introduces two changes:
1. reduces the threshold on hermitian sanity checks on J2C integrals from `1e-12` to `1e-10`. This is followed up by explicitly symmetrizing j2c.
2. Fix the old -> new data structure requirements for `wannier_fock.py` example script.