### PR TITLE
[Hot Fix] checks on j2c eigs and condition number

### DIFF
--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -654,13 +654,18 @@ def cholesky_decomposed_metric(j2c_k, cell, inv=False):
 
 def eigenvalue_decomposed_metric(j2c_k, cell, inv=False):
     j2c_negative = None
+    cond_num = np.linalg.cond(j2c_k)
+    if cond_num > 1e12:
+        raise UserWarning(f"Condition number of j2c_k ({cond_num}) is too large. Consider using a smallr aux. basis.")
+
     eigs, vecs = LA.eigh(j2c_k)
-    assert np.all(eigs > 0), "j2c metric has non-positive eigenvalues"
-    eigs_trim = eigs[eigs > J2C_LIN_DEP_THRESH]
+    assert np.all(eigs > -J2C_LIN_DEP_THRESH), "j2c metric has non-positive eigenvalues"
+    eig_mask = eigs > np.max(eigs) * J2C_LIN_DEP_THRESH
+    eigs_trim = eigs[eig_mask]
     if inv:
-        j2c_sqrt_k = vecs[:, eigs > J2C_LIN_DEP_THRESH].conj().T / np.sqrt(eigs_trim).reshape(-1, 1)
+        j2c_sqrt_k = vecs[:, eig_mask].conj().T / np.sqrt(eigs_trim).reshape(-1, 1)
     else:
-        j2c_sqrt_k = vecs[:, eigs > J2C_LIN_DEP_THRESH] * np.sqrt(eigs_trim).reshape(1, -1)
+        j2c_sqrt_k = vecs[:, eig_mask] * np.sqrt(eigs_trim).reshape(1, -1)
     # negative eigenvalues can occur in 2D systems with certain Fourier transform conventions,
     # but we can still use the corresponding eigenvectors to define a "negative" subspace for the J2C metric
     if cell.dimension == 2 and cell.low_dim_ft_type != 'inf_vacuum':

--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 import string
+import warnings
 import importlib.metadata as imd
 
 import h5py
@@ -656,7 +657,7 @@ def eigenvalue_decomposed_metric(j2c_k, cell, inv=False):
     j2c_negative = None
     cond_num = np.linalg.cond(j2c_k)
     if cond_num > 1e12:
-        raise UserWarning(f"Condition number of j2c_k ({cond_num}) is too large. Consider using a smallr aux. basis.")
+        warnings.warn(f"Condition number of j2c_k ({cond_num}) is too large. Consider using a smaller aux. basis.")
 
     eigs, vecs = LA.eigh(j2c_k)
     assert np.all(eigs > -J2C_LIN_DEP_THRESH), "j2c metric has non-positive eigenvalues"

--- a/green_mbtools/mint/symmetry_utils.py
+++ b/green_mbtools/mint/symmetry_utils.py
@@ -43,9 +43,9 @@ def fold_to_unit_cell(r_cart_scaled):
     r_rel : ndarray
         The folded Cartesian coordinate within the unit cell (3,).
     """
-    frac = r_cart_scaled
+    frac = np.asarray(r_cart_scaled, dtype=float)
     # Wrap to [-0.5, 0.5) to match atom coordinate convention
-    frac = frac - np.round(frac)
+    frac = np.mod(frac + 0.5, 1.0) - 0.5
     return frac
 
 
@@ -81,6 +81,9 @@ def generate_permutation_info(mycell, symm_op, tol=1e-8, verbose=False):
     partner_idx = np.zeros(n_atom, dtype=int)
     pos_diff = np.zeros((n_atom, 3))
     coords_scaled = mycell.get_scaled_atom_coords().reshape(-1,3)
+    # ensure scaled coordinates are in [-0.5, 0.5)
+    for i in range(coords_scaled.shape[0]):
+        coords_scaled[i] = fold_to_unit_cell(coords_scaled[i])
 
     for i in range(n_atom):
         i_coord = coords_scaled[i]


### PR DESCRIPTION
Improve the checks for negative eigenvalues in j2c, also raise a warning if condition number of j2c matrix is too large. Unfortunately this will be the case for several all-electron calculations - a better fix needs more deliberation.