### PR TITLE
Replace `from_chk` assignment with `init_guess_by_chkfile`

### DIFF
--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -758,7 +758,7 @@ def solve_mean_field(args, mydf, mycell):
     mf.max_cycle = args.max_iter
     mf.chkfile = 'tmp.chk'
     if os.path.exists("tmp.chk"):
-        init_dm = mf.from_chk('tmp.chk')
+        init_dm = mf.init_guess_by_chkfile(mycell, mf.chkfile)
         mf.kernel(init_dm)
     elif args.dm0 is not None:
         init_dm = mf.get_init_guess()
@@ -801,7 +801,7 @@ def solve_mol_mean_field(args, mydf, mycell):
     mf.max_cycle = args.max_iter
     mf.chkfile = 'tmp.chk'
     if os.path.exists("tmp.chk"):
-        init_dm = mf.from_chk('tmp.chk')
+        init_dm = mf.init_guess_by_chkfile(mycell, mf.chkfile)
         mf.kernel(init_dm)
     elif args.dm0 is not None:
         init_dm = mf.get_init_guess()


### PR DESCRIPTION
Trial fix for #35.

This PR changes the restart path to call `init_guess_by_chkfile()` directly instead of using `from_chk()`.

`from_chk()` is only defined on the HF classes, and in practice it just wraps/calls `init_guess_by_chkfile()`. Since `init_guess_by_chkfile()` is defined more generally, using it directly should make the checkpoint restart logic more robust and avoid the PySCF argument-mismatch error seen when `tmp.chk` is present.

The intended behavior is that rerunning a calculation with an existing `tmp.chk` should either restart correctly or fail gracefully, rather than raising:

```text
TypeError: init_guess_by_chkfile() takes from 2 to 3 positional arguments but 4 were given