### PR TITLE
feat: kstruct-driven orthogonalization + on-disk integral rotation + legacy cleanup

### DIFF
--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -1295,7 +1295,7 @@ def construct_gdf(args, mycell, kmesh=None):
     return mydf
 
 
-def compute_ewald_correction(args, cell, kmesh, filename):
+def compute_ewald_correction(args, cell, kmesh, filename, X_k=None):
     # Use gaussian density fitting to get fitted densities
     mydf = int_utils.GreenGDF(cell)
     mydf.space_symm = bool(args.space_symm)
@@ -1309,7 +1309,7 @@ def compute_ewald_correction(args, cell, kmesh, filename):
     # Coulomb kernel mesh
     if args.Nk > 0:
         mydf.mesh = [args.Nk, args.Nk, args.Nk]
-    int_utils.compute_ewald_correction(args, mydf, kmesh, cell.nao_nr(), filename)
+    int_utils.compute_ewald_correction(args, mydf, kmesh, cell.nao_nr(), filename, X_k=X_k)
 
 
 def compute_df_int_dca(args, mycell, kmesh, lattice_kmesh, nao, X_k):

--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -390,6 +390,8 @@ def orthogonalize(mydf, orth, X_k, X_inv_k, F, T, hf_dm, S, mf=None):
         Sk = S[0, ik]
         if orth == "lowdin":
             x, x_pinv = ortho_utils.lowdin_per_k(Sk)
+        elif orth == "symmetric_lowdin":
+            x, x_pinv = ortho_utils.symmetric_lowdin_per_k(Sk)
         elif orth == "mo":
             # For ns == 2, no single C diagonalizes both F_alpha and F_beta;
             # diagonalize the spin-averaged Fock against S to obtain a
@@ -456,11 +458,12 @@ def add_common_params(parser):
     parser.add_argument("--output_path", type=str, default="input.h5", help="output file with initial data")
     parser.add_argument(
         "--orth", type=str, default="none",
-        choices=["none", "lowdin", "mo", "natural", "0", "1"],
+        choices=["none", "lowdin", "symmetric_lowdin", "mo", "natural", "0", "1"],
         help=(
             "Orbital basis for stored quantities: "
             "'none' = keep AO basis (legacy '0'); "
-            "'lowdin' = symmetric S^{-1/2} orthogonalization (legacy '1'); "
+            "'lowdin' = canonical Löwdin V·Lambda^{-1/2} (legacy '1'); "
+            "'symmetric_lowdin' = Hermitian Löwdin S^{-1/2}; "
             "'mo' = canonical MOs from mean-field; "
             "'natural' = natural orbitals from mean-field density matrix."
         ),

--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -5,6 +5,7 @@ import os
 
 import h5py
 import numpy as np
+import scipy.linalg as LA
 import pyscf.lib.chkfile as chk
 from io import StringIO
 from numba import jit
@@ -18,6 +19,7 @@ from pyscf.pbc.lib import kpts as libkpts
 
 from . import integral_utils as int_utils
 from . import kpt_utils
+from . import ortho_utils
 from .symmetry_utils import get_representation, get_spinor_representation
 from ..version import __version__
 
@@ -360,26 +362,50 @@ def save_data(args, mycell, mf, kmesh, ind, weight, num_ik, ir_list, conj_list, 
     inp_data.close()
 
 
-def orthogonalize(mydf, orth, X_k, X_inv_k, F, T, hf_dm, S):
+def orthogonalize(mydf, orth, X_k, X_inv_k, F, T, hf_dm, S, mf=None):
     '''
-    Transform Fock-matrix, non-interacting Hamiltonian, density matrix and overlap matrix into an orthogonal basis
+    Transform Fock-matrix, non-interacting Hamiltonian, density matrix and overlap matrix into an orthogonal basis.
+
+    ``orth`` selects the per-k transformation:
+      - "none"    : identity (AO basis preserved)
+      - "lowdin"  : symmetric S^{-1/2} orthogonalization
+      - "mo"      : canonical molecular orbitals from ``mf.mo_coeff``
+      - "natural" : natural orbitals from the mean-field density matrix
+
+    ``mf`` is required for "mo"; "natural" uses ``hf_dm``. Per-k basis
+    construction is delegated to ``ortho_utils.{lowdin,mo,natural}_per_k``.
     '''
+    if orth == "mo" and mf is None:
+        raise ValueError("orthogonalize: mf is required for orth='mo'.")
+
+    ns = hf_dm.shape[0]
     maxdiff = -1
     old_shape = [-1, -1]
     for ik, k in enumerate(mydf.kpts):
-        if orth == 0:
+        if orth == "none":
             X_inv_k.append(np.eye(F.shape[2], dtype=np.complex128))
             X_k.append(np.eye(F.shape[2], dtype=np.complex128))
             continue
 
-        s_ev, s_eb = np.linalg.eigh(S[0, ik])
+        Sk = S[0, ik]
+        if orth == "lowdin":
+            x, x_pinv = ortho_utils.lowdin_per_k(Sk)
+        elif orth == "mo":
+            # For ns == 2, no single C diagonalizes both F_alpha and F_beta;
+            # diagonalize the spin-averaged Fock against S to obtain a
+            # spin-symmetric MO basis. For ns == 1 use mf.mo_coeff directly.
+            if ns == 2:
+                F_bar = 0.5 * (F[0, ik] + F[1, ik])
+                _, C_k = LA.eigh(F_bar, Sk)
+            else:
+                C_k = mf.mo_coeff[ik]
+            x, x_pinv = ortho_utils.mo_per_k(Sk, C_k)
+        elif orth == "natural":
+            dmk = 0.5 * (hf_dm[0, ik] + hf_dm[1, ik]) if ns == 2 else hf_dm[0, ik]
+            x, x_pinv = ortho_utils.natural_per_k(Sk, dmk)
+        else:
+            raise ValueError(f"orthogonalize: unknown orth '{orth}'.")
 
-        # Remove all eigenvalues < threshold
-        istart = s_ev.searchsorted(1e-9)
-        s_sqrtev = np.sqrt(s_ev[istart:])
-
-        x_pinv = s_eb[:, istart:] * s_sqrtev
-        x = (s_eb[:, istart:].conj() * 1 / s_sqrtev).T
         n_ortho, n_nonortho = x.shape
         if old_shape[0] >= 0 and n_ortho != old_shape[0] and n_nonortho != old_shape[1]:
             raise RuntimeError("Error!!! Different k-point have different number of orthogonal basis.")
@@ -394,17 +420,21 @@ def orthogonalize(mydf, orth, X_k, X_inv_k, F, T, hf_dm, S):
         diff_max = np.max(np.abs(diff))
         maxdiff = max(maxdiff, diff_max)
     logging.info(f"max diff from identity {maxdiff}")
+
+    if orth == "none":
+        X_inv_k = np.asarray(X_inv_k).reshape(F.shape[1:])
+        X_k = np.asarray(X_k).reshape(F.shape[1:])
+        return X_k, X_inv_k, S, F, T, hf_dm
+
     X_inv_k = np.asarray(X_inv_k).reshape(F.shape[1:])
     X_k = np.asarray(X_k).reshape(F.shape[1:])
-    # Orthogonalization
-    if orth == 1:
-        F = transform(F, X_k, X_inv_k)
-        # S     = transform(S, X_k, X_inv_k)
-        T = transform(T, X_k, X_inv_k)
-        hf_dm = transform(hf_dm, X_inv_k, X_k)
 
-        S = np.array([np.eye(F.shape[-1], dtype=np.complex128)] * F.shape[1])
-        S = np.array([S, S])
+    F = transform(F, X_k, X_inv_k)
+    T = transform(T, X_k, X_inv_k)
+    hf_dm = transform(hf_dm, X_inv_k, X_k)
+
+    S = np.array([np.eye(F.shape[-1], dtype=np.complex128)] * F.shape[1])
+    S = np.array([S] * ns)
 
     return X_k, X_inv_k, S, F, T, hf_dm
 
@@ -424,7 +454,17 @@ def add_common_params(parser):
     parser.add_argument("--int_path", type=str, default="df_int", help="path to store ewald corrected integrals")
     parser.add_argument("--hf_int_path", type=str, default="df_hf_int", help="path to store hf integrals")
     parser.add_argument("--output_path", type=str, default="input.h5", help="output file with initial data")
-    parser.add_argument("--orth", type=int, default=0, help="Transform to orthogonal basis or not. 0 - no orthogonal transformation, 1 - data is in orthogonal basis.")
+    parser.add_argument(
+        "--orth", type=str, default="none",
+        choices=["none", "lowdin", "mo", "natural", "0", "1"],
+        help=(
+            "Orbital basis for stored quantities: "
+            "'none' = keep AO basis (legacy '0'); "
+            "'lowdin' = symmetric S^{-1/2} orthogonalization (legacy '1'); "
+            "'mo' = canonical MOs from mean-field; "
+            "'natural' = natural orbitals from mean-field density matrix."
+        ),
+    )
     parser.add_argument("--beta", type=float, default=None, help="Emperical parameter for even-Gaussian auxiliary basis")
     parser.add_argument("--active_space", type=int, nargs='+', default=None, help="active space orbitals")
     parser.add_argument("--spin", type=int, default=0, help="Local spin")
@@ -470,6 +510,9 @@ def add_pbc_params(parser):
                               help="Two body finite-size correction. Be default computes the second set of integrals that include simple ewald correction.")
 
 
+_ORTH_ALIASES = {"0": "none", "1": "lowdin"}
+
+
 def init_mol_params(params=None):
     '''
     Initialize argparse.ArgumentParser for Green/WeakCoupling python module and return a prased parameters map with parameters specific for molecular calculations
@@ -477,6 +520,7 @@ def init_mol_params(params=None):
     parser = argparse.ArgumentParser(description="Green/WeakCoupling initialization script")
     add_common_params(parser)
     args = parser.parse_args(args=params)
+    args.orth = _ORTH_ALIASES.get(args.orth, args.orth)
     args.basis = parse_basis(args.basis)
     args.auxbasis = parse_basis(args.auxbasis)
     args.ecp = parse_basis(args.ecp)
@@ -510,6 +554,7 @@ def init_pbc_params(params=None):
     add_common_params(parser)
     add_pbc_params(parser)
     args = parser.parse_args(args=params)
+    args.orth = _ORTH_ALIASES.get(args.orth, args.orth)
     if len(args.nk) == 1:
         args.nk = [args.nk[0], args.nk[0], args.nk[0]]
     elif len(args.nk) != 3:
@@ -839,7 +884,7 @@ def store_kstruct_ops_info(args, mycell, kmesh, kstruct, X_k=None, X_inv_k=None)
     X_k : numpy.ndarray, optional
         Orthogonalization matrices in the full BZ, shape ``(nk, nao, nao)``
         (or spin-orbital analog). Required together with ``X_inv_k`` when
-        ``args.orth == 1`` to rotate AO-space symmetry operators into the
+        ``args.orth != "none"`` to rotate AO-space symmetry operators into the
         orthogonalized basis.
     X_inv_k : numpy.ndarray, optional
         Inverse orthogonalization matrices on irreducible k-points, indexed by
@@ -925,12 +970,12 @@ def store_kstruct_ops_info(args, mycell, kmesh, kstruct, X_k=None, X_inv_k=None)
 
     # If quantities are saved in an orthogonalized basis, rotate symmetry operators
     # to the same basis so U(k) reconstructs H/F/G consistently.
-    if (args.orth == 1):
+    if args.orth != "none":
         if (X_k is None or X_inv_k is None):
             raise ValueError(
                 "Cannot transform symmetry operators to orthogonal basis: "
                 "missing transformation matrices X_k and/or X_inv_k. "
-                "(--orth=1 requires --grid_only=false to compute mean-field quantities)"
+                f"(--orth={args.orth} requires --grid_only=false to compute mean-field quantities)"
             )
         # get mapping from full BZ idx to idx (still in full BZ) of the corresponding irreducible point
         bz2ibz = kstruct.ibz2bz[kstruct.bz2ibz]

--- a/green_mbtools/mint/common_utils.py
+++ b/green_mbtools/mint/common_utils.py
@@ -379,6 +379,15 @@ def orthogonalize(mydf, orth, X_k, X_inv_k, F, T, hf_dm, S, mf=None):
         raise ValueError("orthogonalize: mf is required for orth='mo'.")
 
     ns = hf_dm.shape[0]
+    if orth == "mo" and ns == 2:
+        # No single C diagonalizes both spin Fock blocks; we fall back to the
+        # spin-averaged Fock. The resulting MOs are not the eigenstates of
+        # either F_alpha or F_beta individually.
+        logging.warning(
+            "orthogonalize: orth='mo' with ns=2 (UHF/UKS); using "
+            "spin-averaged MOs (eigenstates of 0.5*(F_alpha+F_beta)), "
+            "not the canonical alpha/beta MOs."
+        )
     maxdiff = -1
     old_shape = [-1, -1]
     for ik, k in enumerate(mydf.kpts):

--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -23,12 +23,14 @@ from . import kpt_utils
 J2C_LIN_DEP_THRESH = 1e-10
 
 
-# AO block of X_k[ik] for ERI rotation; for X2C the spinor X is (2·nao)×(2·nao)
-# and we want the upper-left nao×nao block, matching init_seet.py's X_ERI_k.
-# Three-center integral chunks are stored as (NQ, nao, nao), so we require a
-# square orthogonalizer here. Rectangular X — produced by lowdin_per_k when
-# linear dependencies are dropped — would yield (NQ, n_ortho, n_ortho) chunks
-# that don't fit the on-disk shape; reject with a clear error in that case.
+# AO block of X_k[ik] for ERI rotation. For X2C the spinor X is
+# (2·nao, 2·nao) and we slice the upper-left nao×nao block — valid only
+# because the CLI guards (pyscf_init / init_seet) restrict X2C
+# orthogonalization to Löwdin variants, whose X inherits the
+# block-diagonal spin structure of the spinor S. MO and natural-orbital
+# rotations are refused upstream for X2C precisely because their X
+# would not be block-diagonal. Rectangular X (rank-deficient case)
+# is rejected here as it can't fit the (NQ, nao, nao) chunk shape.
 def _x_block_for_eri(X_k, ik, nao):
     Xi = np.asarray(X_k[ik])
     if Xi.shape == (nao, nao):

--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -23,6 +23,28 @@ from . import kpt_utils
 J2C_LIN_DEP_THRESH = 1e-10
 
 
+# AO block of X_k[ik] for ERI rotation; for X2C the spinor X is (2·nao)×(2·nao)
+# and we want the upper-left nao×nao block, matching init_seet.py's X_ERI_k.
+def _x_block_for_eri(X_k, ik, nao):
+    Xi = np.asarray(X_k[ik])
+    if Xi.shape[-1] == nao:
+        return Xi
+    if Xi.shape[-1] == 2 * nao:
+        return Xi[:nao, :nao]
+    raise ValueError(
+        f"_x_block_for_eri: X_k[{ik}] has shape {Xi.shape}; expected last "
+        f"dim {nao} or {2*nao}."
+    )
+
+
+# Lpq_ortho[Q] = X_i @ Lpq[Q] @ X_j.conj().T — the "X Z X†" convention used by
+# the per-k ortho primitives; pairs with the dm stored by common_utils.orthogonalize
+# so the Hartree contraction Σ_{ab} L[Q,a,b] * dm[b,a] inside mbpt's HF kernel
+# reduces to its AO value.
+def _rotate_Lpq(Lpq, X_i, X_j):
+    return np.einsum("Ia,Qab,Jb->QIJ", X_i, Lpq, X_j.conj(), optimize=True)
+
+
 def compute_kG(k, Gv, wrap_around, mesh, cell):
     if abs(k).sum() > 1e-9:
         kG = k + Gv
@@ -345,15 +367,26 @@ def compute_integrals(args, mycell, mydf, kmesh, nao, X_k=None, basename = "df_i
     buffer = np.zeros((chunk_size, NQ, nao, nao), dtype=complex)
     Lpq_mo = np.zeros((NQ, nao, nao), dtype=complex)
     chunk_indices = []
+    # Rotate three-center integrals into the AO->ortho basis when
+    # args.orth != "none", so on-disk V matches S/F/T/dm in input.h5.
+    rotate = (X_k is not None and len(X_k) == kmesh.shape[0]
+              and args.orth != "none")
+
     for i in kpair_irre_list:
         k1 = kptis[i]
         k2 = kptjs[i]
+        k1_idx, k2_idx = kptij_idx[i]
+        if rotate:
+            X_i = _x_block_for_eri(X_k, k1_idx, nao)
+            X_j = _x_block_for_eri(X_k, k2_idx, nao)
         # auxiliary basis index
         s1 = 0
         for XXX in mydf.sr_loop((k1,k2), max_memory=4000, compact=False):
             LpqR = XXX[0]
             LpqI = XXX[1]
             Lpq = (LpqR + LpqI*1j).reshape(LpqR.shape[0], nao, nao)
+            if rotate:
+                Lpq = _rotate_Lpq(Lpq, X_i, X_j)
             buffer[cnt% chunk_size, s1:s1+Lpq.shape[0], :, :] = Lpq[0:Lpq.shape[0],:,:]
             # s1 = NQ at maximum.
             s1 += Lpq.shape[0]
@@ -363,6 +396,8 @@ def compute_integrals(args, mycell, mydf, kmesh, nao, X_k=None, basename = "df_i
                 LpqR = XXX[0]
                 LpqI = XXX[1]
                 Lpq = (LpqR + LpqI*1j).reshape(LpqR.shape[0], nao, nao)
+                if rotate:
+                    Lpq = _rotate_Lpq(Lpq, X_i, X_j)
                 buffer[cnt% chunk_size, s1:s1+Lpq.shape[0], :, :] = Lpq[0:Lpq.shape[0],:,:]
                 # s1 = NQ at maximum.
                 s1 += Lpq.shape[0]
@@ -415,7 +450,7 @@ def weighted_coulG_ewald_2nd(mydf, kpt, exx, mesh):
     mydf.kpts = oldkpts
     return coulG
 
-def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5"):
+def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5", X_k=None):
     # global full_k_mesh
     data = h5py.File(filename, "w")
     EW     = data.create_group("EW")
@@ -472,6 +507,12 @@ def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5")
     df1.build()
     _, nk2, nk3 = args.nk
 
+    # Rotate Ewald-correction buffers to AO->ortho basis when
+    # args.orth != "none", to match the V integrals written by
+    # compute_integrals (avoids mixing V_ortho with EW_AO downstream).
+    rotate = (X_k is not None and len(X_k) == kmesh.shape[0]
+              and args.orth != "none")
+
     # We know that G=0 contribution diverge only when q = 0
     # so we loop over (k1,k1) pairs
     for i, ki in enumerate(kmesh):
@@ -510,8 +551,15 @@ def compute_ewald_correction(args, maindf, kmesh, nao, filename = "df_ewald.h5")
             buffer2[s1:s1+Lpq.shape[0], :, :] = Lpq_mo[0:Lpq.shape[0],:,:]
             s1 += Lpq.shape[0]
 
-        EW["{}".format(i)] = (buffer1 - buffer2).view(np.float64)
-        EW_bar["{}".format(i)] = buffer2.view(np.float64)
+        if rotate:
+            X_i = _x_block_for_eri(X_k, i, nao)
+            ew_arr = _rotate_Lpq(buffer1 - buffer2, X_i, X_i)
+            ew_bar_arr = _rotate_Lpq(buffer2, X_i, X_i)
+        else:
+            ew_arr = buffer1 - buffer2
+            ew_bar_arr = buffer2
+        EW["{}".format(i)] = ew_arr.view(np.float64)
+        EW_bar["{}".format(i)] = ew_bar_arr.view(np.float64)
         buffer1[:] = 0.0
         buffer2[:] = 0.0
 

--- a/green_mbtools/mint/integral_utils.py
+++ b/green_mbtools/mint/integral_utils.py
@@ -25,15 +25,23 @@ J2C_LIN_DEP_THRESH = 1e-10
 
 # AO block of X_k[ik] for ERI rotation; for X2C the spinor X is (2·nao)×(2·nao)
 # and we want the upper-left nao×nao block, matching init_seet.py's X_ERI_k.
+# Three-center integral chunks are stored as (NQ, nao, nao), so we require a
+# square orthogonalizer here. Rectangular X — produced by lowdin_per_k when
+# linear dependencies are dropped — would yield (NQ, n_ortho, n_ortho) chunks
+# that don't fit the on-disk shape; reject with a clear error in that case.
 def _x_block_for_eri(X_k, ik, nao):
     Xi = np.asarray(X_k[ik])
-    if Xi.shape[-1] == nao:
+    if Xi.shape == (nao, nao):
         return Xi
-    if Xi.shape[-1] == 2 * nao:
+    if Xi.shape == (2 * nao, 2 * nao):
         return Xi[:nao, :nao]
     raise ValueError(
-        f"_x_block_for_eri: X_k[{ik}] has shape {Xi.shape}; expected last "
-        f"dim {nao} or {2*nao}."
+        f"_x_block_for_eri: X_k[{ik}] has shape {Xi.shape}; expected "
+        f"({nao}, {nao}) or ({2*nao}, {2*nao}). The three-center integral "
+        "storage path requires a square orthogonalizer; rank-deficient "
+        "transforms (lowdin_per_k with linear dependencies, or canonical "
+        "orthogonalization dropping modes) cannot be written into "
+        "df_hf_int / df_int."
     )
 
 

--- a/green_mbtools/mint/ortho_utils.py
+++ b/green_mbtools/mint/ortho_utils.py
@@ -1,30 +1,7 @@
 import numpy as np
 import scipy.linalg as LA
-from functools import reduce
-from ..pesto import orth
 from .symmetry_utils import get_representation, get_spinor_representation
 
-def wrap_k(k):
-    while k < 0 :
-        k = 1 + k
-    while (k - 9.9999999999e-1) > 0.0 :
-        k = k - 1
-    return k
-
-def normalize(Sv):
-    Svo = np.zeros(Sv.shape, dtype=Sv.dtype)
-    for iv, v in enumerate(Sv.T):
-        ss = np.sign(v[0])*(-1)**iv
-        Svo[:,iv] = ss*v.T
-    return Svo
-
-def avg(kpts, X):
-    '''
-    Average momentum dependent quantity 
-    '''
-    xxx = (X[kpts[0]] + X[kpts[1 % len(kpts)]].conj())/2
-    for ikk, kk in enumerate(kpts):
-        X[kk] = (xxx if (ikk % 2) == 0 else xxx.conj())
 
 def lowdin_per_k(Sk, tol=1e-9):
     '''
@@ -53,6 +30,26 @@ def mo_per_k(Sk, C_k):
     '''
     C_k = np.asarray(C_k, dtype=np.complex128)
     return C_k.conj().T, Sk @ C_k
+
+
+def symmetric_lowdin_per_k(Sk, tol=1e-9):
+    '''
+    Symmetric (Hermitian) Löwdin orthogonalization for a single k-point.
+
+    Returns ``(X = S^{-1/2}, X_inv = S^{+1/2})`` — both Hermitian — in
+    the ``X Z X†`` convention. Distinguished from ``lowdin_per_k``,
+    which returns the *canonical* Löwdin form ``X = Λ^{-1/2} V†`` (a
+    different gauge on the orthogonal basis). Eigenvalues of ``Sk``
+    below ``tol`` are discarded; when linear dependencies are dropped
+    the result is rectangular like the canonical case.
+    '''
+    s_ev, s_eb = np.linalg.eigh(Sk)
+    istart = s_ev.searchsorted(tol)
+    s_sqrt = np.sqrt(s_ev[istart:])
+    V = s_eb[:, istart:]
+    X = (V / s_sqrt) @ V.conj().T
+    X_inv = (V * s_sqrt) @ V.conj().T
+    return X.astype(np.complex128), X_inv.astype(np.complex128)
 
 
 def _S_inv_half(Sk):
@@ -138,6 +135,8 @@ def _build_X_ibz(mode, S_ibz, F_ibz, dm_ibz, mo_coeff_ibz,
         Sk = S_ibz[i_ir]
         if mode == "lowdin":
             x, x_inv = lowdin_per_k(Sk, tol=tol_sing)
+        elif mode == "symmetric_lowdin":
+            x, x_inv = symmetric_lowdin_per_k(Sk, tol=tol_sing)
         elif mode == "mo":
             if mo_coeff_ibz is not None:
                 Ck = mo_coeff_ibz[i_ir]
@@ -160,7 +159,7 @@ def _build_X_ibz(mode, S_ibz, F_ibz, dm_ibz, mo_coeff_ibz,
         else:
             raise ValueError(
                 f"build_X_kspace: unknown mode {mode!r} "
-                "(expected 'lowdin', 'mo', or 'natural')."
+                "(expected 'lowdin', 'symmetric_lowdin', 'mo', or 'natural')."
             )
         X_per_irrep[i_ir] = np.asarray(x, dtype=np.complex128)
         Xinv_per_irrep[i_ir] = np.asarray(x_inv, dtype=np.complex128)
@@ -288,7 +287,7 @@ def build_X_kspace(
 
     Parameters
     ----------
-    mode : {"lowdin", "mo", "natural"}
+    mode : {"lowdin", "symmetric_lowdin", "mo", "natural"}
         IBZ primitive to use.
     kstruct : pyscf.pbc.lib.kpts.KPoints
         Same object the rest of mbtools uses (e.g. from
@@ -324,10 +323,10 @@ def build_X_kspace(
     X_k     : (nk, n_ortho, n) complex128 ndarray
     X_inv_k : (nk, n,        n_ortho) complex128 ndarray
     '''
-    if spinor and mode != "lowdin":
+    if spinor and mode not in ("lowdin", "symmetric_lowdin"):
         raise NotImplementedError(
-            f"build_X_kspace: spinor=True only supported for mode='lowdin', "
-            f"got mode={mode!r}."
+            f"build_X_kspace: spinor=True only supported for mode in "
+            f"{{'lowdin', 'symmetric_lowdin'}}, got mode={mode!r}."
         )
     if mode == "natural" and (dm_ibz is None or F_ibz is None):
         raise ValueError(
@@ -433,227 +432,3 @@ def build_X_kspace_from_ao_reps(
     )
 
 
-def symmetrical_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):
-    X_k = []
-    X_inv_k = []
-    pairing = {}
-    unique_kpts = []
-    # generate list of unique k-points by applying an inversion symmetry
-    for ik, k in enumerate(kmesh):
-        for ikp, kp in enumerate(kmesh):
-            minus_k = [wrap_k(-kk) for kk in k]
-            if np.allclose(minus_k, kp) and ikp not in pairing.keys():
-                pairing[ikp] = ik
-                unique_kpts.append(ik)
-        if ik not in pairing.keys():
-            pairing[ik] = ik
-    # find the list of k-points that are the same by inversion symmetry and apply the k-symmetrization
-    for ik in unique_kpts:
-        kpts = []
-        for ikp in pairing.keys():
-            if pairing[ikp] == ik:
-                kpts.append(ikp)
-        avg(kpts, dm)
-        avg(kpts, F_up)
-        avg(kpts, F_dn)
-        avg(kpts, T_up)
-        avg(kpts, T_dn)
-
-    # Compute transformation matrices
-    for ik, k in enumerate(kmesh):
-        # check whether matrices should be real by inversion symmetry
-        if np.allclose(k, [wrap_k(-kk) for kk in k]):
-            if Debug_print:
-                print(k)
-            dmk = dm[ik].real
-            Sk = S[ik].real
-        else:
-            dmk = dm[ik]
-            Sk = S[ik]
-
-
-        x, x_pinv = lowdin_per_k(Sk)
-
-        n_ortho, n_nonortho = x.shape
-
-        if Debug_print:
-            print("S", np.allclose(np.dot(x_pinv, x_pinv.conj().T), S[ik]))
-            print("X X^-1", np.allclose(np.dot(x, x_pinv), np.eye(x.shape[0])))
-            print("X* X^-1*", np.allclose(np.dot(x.conj().T, x_pinv.conj().T), np.eye(x.shape[0])))
-
-        # check that direct and inverse symmetries are consistent
-        assert(np.allclose(np.dot(x, x_pinv), np.eye(x.shape[0])))
-
-        # store transformation basis for current k-point
-        xx_inv = x_pinv.conj().T.astype(np.complex128)
-        xx = x.conj().T.astype(np.complex128)
-        X_inv_k.append(xx_inv.copy())
-        X_k.append(xx.copy())
-
-        minus_k = [wrap_k(-kk) for kk in k]
-
-        for ikk, kk in enumerate(kmesh):
-            if np.allclose(kk, minus_k) and ikk < ik:
-                # X_inv_k.append(np.copy(X_inv_k[ikk]))
-                # X_k.append(np.copy(X_k[ikk]))
-                if Debug_print:
-                    print("============== reduced point ================")
-                    print("S", np.allclose(S[ikk].conj(), S[ik]))
-                    print("Sev", np.allclose(LA.eigvalsh(S[ikk]), LA.eigvalsh(S[ik])))
-                    # print LA.eigvalsh(S[ikk]), "\n\n=====\n\n", LA.eigvalsh(S[ik])
-                    print("S", np.allclose(np.dot(X_inv_k[ikk].T, X_inv_k[ikk].conj()), S[ik]))
-                    print("S2", np.allclose(X_inv_k[ikk], xx_inv.conj().T.conj()))
-                assert(np.allclose(np.dot(X_inv_k[ik].conj().T, X_inv_k[ik]), S[ik]))
-                assert(np.allclose(np.dot(X_inv_k[ikk].T, X_inv_k[ikk].conj()), S[ik]))
-                X_inv_k[ik] = np.copy(X_inv_k[ikk].conj())
-                X_k[ik] = np.copy(X_k[ikk].conj())
-                continue
-    return X_inv_k, X_k
-
-def canonical_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):
-    X_k = []
-    X_inv_k = []
-    pairing = {}
-    unique_kpts = []
-    # generate list of unique k-points by applying an inversion symmetry
-    for ik, k in enumerate(kmesh):
-        for ikp, kp in enumerate(kmesh):
-            minus_k = [wrap_k(-kk) for kk in k]
-            if np.allclose(minus_k, kp) and ikp not in pairing.keys():
-                pairing[ikp] = ik
-                unique_kpts.append(ik)
-        if ik not in pairing.keys():
-            pairing[ik] = ik
-    # find the list of k-points that are the same by inversion symmetry and apply the k-symmetrization
-    for ik in unique_kpts:
-        kpts = []
-        for ikp in pairing.keys():
-            if pairing[ikp] == ik:
-                kpts.append(ikp)
-        avg(kpts, dm)
-        #avg(kpts, S)
-        avg(kpts, F_up)
-        avg(kpts, F_dn)
-        avg(kpts, T_up)
-        avg(kpts, T_dn)
-
-    # Compute transformation matrices
-    for ik, k in enumerate(kmesh):
-        # check whether matrices should be real by inversion symmetry
-        if np.allclose(k, [wrap_k(-kk) for kk in k]):
-            if Debug_print:
-                print(k)
-            dmk = dm[ik].real
-            Sk = S[ik].real
-        else:
-            dmk = dm[ik]
-            Sk = S[ik]
-
-
-        x, x_pinv = lowdin_per_k(Sk)
-
-        n_ortho, n_nonortho = x.shape
-        if Debug_print:
-            print("S", np.allclose(np.dot(x_pinv, x_pinv.conj().T), S[ik]))
-            print("X X^-1", np.allclose(np.dot(x, x_pinv), np.eye(x.shape[0])))
-            print("X* X^-1*", np.allclose(np.dot(x.conj().T, x_pinv.conj().T), np.eye(x.shape[0])))
-
-        # check that direct and inverse symmetries are consistent
-        assert(np.allclose(np.dot(x, x_pinv), np.eye(x.shape[0])))
-
-        # store transformation basis for current k-point
-        xx_inv = x_pinv.conj().T
-        xx = x.conj().T
-        X_inv_k.append(xx_inv.copy())
-        X_k.append(xx.copy())
-
-        minus_k = [wrap_k(-kk) for kk in k]
-        for ikk, kk in enumerate(kmesh):
-            if np.allclose(kk, minus_k) and ikk < ik:
-                # X_inv_k.append(np.copy(X_inv_k[ikk]))
-                # X_k.append(np.copy(X_k[ikk]))
-                if Debug_print:
-                    print("============== reduced point ================")
-                    print("S", np.allclose(S[ikk].conj(), S[ik]))
-                    print("Sev", np.allclose(LA.eigvalsh(S[ikk]), LA.eigvalsh(S[ik])))
-                    # print LA.eigvalsh(S[ikk]), "\n\n=====\n\n", LA.eigvalsh(S[ik])
-                    print("S", np.allclose(np.dot(X_inv_k[ikk].T, X_inv_k[ikk].conj()), S[ik]))
-                    print("S2", np.allclose(X_inv_k[ikk], xx_inv.conj().T.conj()))
-                assert(np.allclose(np.dot(X_inv_k[ik].conj().T, X_inv_k[ik]), S[ik]))
-                assert(np.allclose(np.dot(X_inv_k[ikk].T, X_inv_k[ikk].conj()), S[ik]))
-                X_inv_k[ik] = np.copy(X_inv_k[ikk].conj())
-                X_k[ik] = np.copy(X_k[ikk].conj())
-                continue
-
-    return X_inv_k, X_k
-
-def natural_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):
-    '''
-    Compute transformation matricies for natural orbtial basis from spin-averaged density matrix
-    ---
-    
-    '''
-    X_k = []
-    X_inv_k = []
-    pairing = {}
-    unique_kpts = []
-    # generate list of unique k-points by applying an inversion symmetry
-    for ik, k in enumerate(kmesh):
-        for ikp, kp in enumerate(kmesh):
-            minus_k = [wrap_k(-kk) for kk in k]
-            if np.allclose(minus_k, kp) and ikp not in pairing.keys():
-                pairing[ikp] = ik
-                unique_kpts.append(ik)
-        if ik not in pairing.keys():
-            pairing[ik] = ik
-    # find the list of k-points that are the same by inversion symmetry and apply the k-symmetrization
-    for ik in unique_kpts:
-        kpts = []
-        for ikp in pairing.keys():
-            if pairing[ikp] == ik:
-                kpts.append(ikp)
-        avg(kpts, dm)
-        avg(kpts, F_up)
-        avg(kpts, F_dn)
-        avg(kpts, T_up)
-        avg(kpts, T_dn)
-
-    # Compute transformation matrices
-    for ik, k in enumerate(kmesh):
-        # check whether matrices should be real by inversion symmetry
-        if np.allclose(k, [wrap_k(-kk) for kk in k]):
-            dmk = dm[ik].real
-            Sk = S[ik].real
-        else:
-            dmk = dm[ik]
-            Sk = S[ik]
-
-        # compute natural orbital basis
-        Svi, Sv = natural_per_k(Sk, dmk)
-
-        # Check that transformations for the inversion symmetries are consistent
-        if ik != pairing[ik] and not np.allclose(reduce(np.dot, (Sv, dm[ik], Sv.conj().T)), reduce(np.dot, (Sv.conj(), dm[pairing[ik]], Sv.T)),
-                          atol=1e-7):
-            print(False, np.max(np.abs(reduce(np.dot, (Sv, dm[ik], Sv.conj().T)) - reduce(np.dot, (Sv.conj(), dm[pairing[ik]], Sv.T))) ))
-            print(ik, k, pairing[ik], kmesh[pairing[ik]])
-            print("A", reduce(np.dot, (Sv, dm[ik], Sv.conj().T)))
-            print("B", reduce(np.dot, (Sv.conj(), dm[pairing[ik]], Sv.T)))
-        else:
-            pass
-
-        # here we assume that the direct transformation is for quantities like Self-energy and Fock matrix
-        # and the inverse transformation if for quantities like density matrix and Green's function
-        x_pinv = Sv
-        x  = Svi
-
-        # check that direct and inverse symmetries are consistent
-        assert(np.allclose(np.dot(x, x_pinv), np.eye(x.shape[0])))
-
-        dmkd = orth.transform_per_k(dmk, x_pinv.conj().T, x.conj().T)
-        assert(np.allclose(dmkd, np.diag(np.diag(dmkd))))
-
-        # store transformation basis for current k-point
-        X_inv_k.append(x_pinv.copy())
-        X_k.append(x.copy())
-
-    return X_inv_k, X_k

--- a/green_mbtools/mint/ortho_utils.py
+++ b/green_mbtools/mint/ortho_utils.py
@@ -25,6 +25,48 @@ def avg(kpts, X):
     for ikk, kk in enumerate(kpts):
         X[kk] = (xxx if (ikk % 2) == 0 else xxx.conj())
 
+def lowdin_per_k(Sk, tol=1e-9):
+    '''
+    Symmetric (Löwdin) S^{-1/2} orthogonalization for a single k-point.
+
+    Returns ``(X, X_inv)`` in the convention used by
+    ``common_utils.transform`` (i.e. transforms apply as ``X Z X†``):
+        X     = S^{-1/2}   (shape (n_ortho, nao))
+        X_inv = S^{+1/2}   (shape (nao, n_ortho))
+    Eigenvalues of ``Sk`` below ``tol`` are discarded.
+    '''
+    s_ev, s_eb = np.linalg.eigh(Sk)
+    istart = s_ev.searchsorted(tol)
+    s_sqrtev = np.sqrt(s_ev[istart:])
+    x_pinv = s_eb[:, istart:] * s_sqrtev
+    x = (s_eb[:, istart:].conj() * (1.0 / s_sqrtev)).T
+    return x, x_pinv
+
+
+def mo_per_k(Sk, C_k):
+    '''
+    Canonical-MO basis for a single k-point from MO coefficients ``C_k``
+    satisfying ``C† S C = I``.
+
+    Returns ``(X = C†, X_inv = S C)`` in the ``X Z X†`` convention.
+    '''
+    C_k = np.asarray(C_k, dtype=np.complex128)
+    return C_k.conj().T, Sk @ C_k
+
+
+def natural_per_k(Sk, dmk):
+    '''
+    Natural-orbital basis for a single k-point from density matrix ``dmk``.
+
+    Solves the generalized eigenproblem ``dm v = S^{-1} v n`` and returns
+    ``(X, X_inv)`` in the ``X Z X†`` convention such that
+    ``X_inv @ dm @ X_inv†`` is diagonal (occupations on the diagonal).
+    '''
+    _, Sv = LA.eigh(dmk, np.linalg.inv(Sk))
+    Sv = Sv.conj().T.astype(np.complex128)
+    return LA.inv(Sv), Sv
+
+
 def symmetrical_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):
     X_k = []
     X_inv_k = []
@@ -64,9 +106,7 @@ def symmetrical_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False
             Sk = S[ik]
 
 
-        x_pinv = LA.sqrtm(Sk)
-        x = LA.inv(x_pinv)
-
+        x, x_pinv = lowdin_per_k(Sk)
 
         n_ortho, n_nonortho = x.shape
 
@@ -144,17 +184,7 @@ def canonical_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):
             Sk = S[ik]
 
 
-        s_ev, s_eb = np.linalg.eigh(Sk)
-
-        # Remove all eigenvalues < threshold
-        istart = s_ev.searchsorted(1e-9)
-        s_sqrtev = np.sqrt(s_ev[istart:])
-
-        # Moore-Penrose pseudoinverse of X:  (X^+ * X)^(-1) * X^+
-        # TODO: use least squares instead
-        x_pinv = s_eb[:, istart:] * s_sqrtev
-        x = (s_eb[:, istart:].conj() * 1 / s_sqrtev).T
-        x = LA.inv(x_pinv)
+        x, x_pinv = lowdin_per_k(Sk)
 
         n_ortho, n_nonortho = x.shape
         if Debug_print:
@@ -233,9 +263,7 @@ def natural_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):
             Sk = S[ik]
 
         # compute natural orbital basis
-        Sd, Sv = LA.eigh(dmk,np.linalg.inv(Sk))
-        Sv = Sv.conj().T.astype(np.complex128)
-        Svi = LA.inv(Sv)
+        Svi, Sv = natural_per_k(Sk, dmk)
 
         # Check that transformations for the inversion symmetries are consistent
         if ik != pairing[ik] and not np.allclose(reduce(np.dot, (Sv, dm[ik], Sv.conj().T)), reduce(np.dot, (Sv.conj(), dm[pairing[ik]], Sv.T)),

--- a/green_mbtools/mint/ortho_utils.py
+++ b/green_mbtools/mint/ortho_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.linalg as LA
 from functools import reduce
 from ..pesto import orth
+from .symmetry_utils import get_representation, get_spinor_representation
 
 def wrap_k(k):
     while k < 0 :
@@ -65,6 +66,351 @@ def natural_per_k(Sk, dmk):
     _, Sv = LA.eigh(dmk, np.linalg.inv(Sk))
     Sv = Sv.conj().T.astype(np.complex128)
     return LA.inv(Sv), Sv
+
+
+def _natural_per_k_with_fock_tiebreak(Sk, dmk, Fk, tol_degen=1e-8):
+    '''
+    Natural orbitals at one k-point with Fock-within-block tie-breaking.
+
+    Diagonalizes ``dmk`` against ``Sk`` to obtain occupations ``n`` and
+    eigenvectors ``V`` (columns) with ``V† S V = I``. Within each block
+    of columns whose occupations agree to ``tol_degen``, additionally
+    diagonalizes the block-projected Fock ``V_B† F V_B`` and rotates the
+    block accordingly. Returns ``(X, X_inv)`` in the ``X Z X†`` convention.
+    '''
+    n_occ, V = LA.eigh(dmk, np.linalg.inv(Sk))
+    V = V.astype(np.complex128)
+    nbf = V.shape[1]
+
+    i = 0
+    while i < nbf:
+        j = i + 1
+        while j < nbf and abs(n_occ[j] - n_occ[i]) < tol_degen:
+            j += 1
+        if j - i > 1:
+            VB = V[:, i:j]
+            FB = VB.conj().T @ Fk @ VB
+            FB = 0.5 * (FB + FB.conj().T)
+            _, W = LA.eigh(FB)
+            V[:, i:j] = VB @ W
+        i = j
+
+    Vh = V.conj().T
+    return LA.inv(Vh), Vh
+
+
+def _build_X_ibz(mode, S_ibz, F_ibz, dm_ibz, mo_coeff_ibz,
+                 tol_sing, tol_degen):
+    '''
+    Per-IBZ orthogonalization step shared by ``build_X_kspace`` and
+    ``build_X_kspace_from_ao_reps``.
+
+    Returns
+    -------
+    X_per_irrep, X_inv_per_irrep : lists of length n_ibz
+        Per-IBZ-point X and X_inv in the ``X Z X†`` convention.
+    '''
+    n_ibz = np.asarray(S_ibz).shape[0]
+    X_per_irrep = [None] * n_ibz
+    Xinv_per_irrep = [None] * n_ibz
+
+    for i_ir in range(n_ibz):
+        Sk = S_ibz[i_ir]
+        if mode == "lowdin":
+            x, x_inv = lowdin_per_k(Sk, tol=tol_sing)
+        elif mode == "mo":
+            if mo_coeff_ibz is not None:
+                Ck = mo_coeff_ibz[i_ir]
+            else:
+                Fk = F_ibz[i_ir]
+                if Fk.ndim == 3:
+                    Fk = 0.5 * (Fk[0] + Fk[1])
+                _, Ck = LA.eigh(Fk, Sk)
+            x, x_inv = mo_per_k(Sk, Ck)
+        elif mode == "natural":
+            dmk = dm_ibz[i_ir]
+            Fk = F_ibz[i_ir]
+            if dmk.ndim == 3:
+                dmk = 0.5 * (dmk[0] + dmk[1])
+            if Fk.ndim == 3:
+                Fk = 0.5 * (Fk[0] + Fk[1])
+            x, x_inv = _natural_per_k_with_fock_tiebreak(
+                Sk, dmk, Fk, tol_degen=tol_degen
+            )
+        else:
+            raise ValueError(
+                f"build_X_kspace: unknown mode {mode!r} "
+                "(expected 'lowdin', 'mo', or 'natural')."
+            )
+        X_per_irrep[i_ir] = np.asarray(x, dtype=np.complex128)
+        Xinv_per_irrep[i_ir] = np.asarray(x_inv, dtype=np.complex128)
+
+    return X_per_irrep, Xinv_per_irrep
+
+
+def _propagate_with_reps(X_per_irrep, Xinv_per_irrep, ibz2bz, bz2ibz,
+                         k_sym_transform_ao, tr_conj):
+    '''
+    Propagate per-IBZ ``(X, X_inv)`` to every BZ point given precomputed
+    AO-space rotations ``k_sym_transform_ao`` and TR flags ``tr_conj``.
+
+    Convention (matching ``common_utils.store_kstruct_ops_info``):
+
+    - Non-TR (``tr_conj[k] == False``): the AO rotation ``U(k)`` is
+      ``get_representation(k, stars_ops[k], ...)`` (or the spinor analog),
+      and ``M(k) = U M(k_ir) U†``. Then
+
+          X(k)     = X(k_ir) @ U†
+          X_inv(k) = U @ X_inv(k_ir)
+
+    - TR (``tr_conj[k] == True``): the stored rotation already
+      incorporates the conjugation factor (e.g. for X2C double group it
+      is ``(U_spinor @ Θ).conj()``), and the reconstruction is
+      ``M(k) = (U M(k_ir) U†).conj()``. Then
+
+          X(k)     = (X(k_ir) @ U†).conj()
+          X_inv(k) = (U @ X_inv(k_ir)).conj()
+
+    so that ``X(k) S(k) X(k)† = I`` at every BZ point.
+    '''
+    ibz2bz_arr = np.asarray(ibz2bz)
+    bz2ibz_arr = np.asarray(bz2ibz)
+    nk = bz2ibz_arr.shape[0]
+
+    sample = X_per_irrep[0]
+    n_ortho, n_basis = sample.shape
+
+    X_k = np.zeros((nk, n_ortho, n_basis), dtype=np.complex128)
+    X_inv_k = np.zeros((nk, n_basis, n_ortho), dtype=np.complex128)
+
+    if tr_conj is None:
+        tr_conj = np.zeros(nk, dtype=bool)
+
+    for ik in range(nk):
+        i_ir = int(bz2ibz_arr[ik])
+        X_ir = X_per_irrep[i_ir]
+        Xinv_ir = Xinv_per_irrep[i_ir]
+        u = k_sym_transform_ao[ik]
+
+        Xk = X_ir @ u.conj().T
+        Xinvk = u @ Xinv_ir
+        if tr_conj[ik]:
+            Xk = Xk.conj()
+            Xinvk = Xinvk.conj()
+        X_k[ik] = Xk
+        X_inv_k[ik] = Xinvk
+
+    return X_k, X_inv_k
+
+
+def _propagate_X_to_star(
+    X_per_irrep,
+    Xinv_per_irrep,
+    kstruct,
+    mycell,
+    spinor=False,
+):
+    '''
+    Build precomputed AO-rotation arrays from ``kstruct`` + ``mycell`` and
+    delegate to ``_propagate_with_reps``.
+    '''
+    nk = kstruct.nkpts
+    stars_ops = kstruct.stars_ops_bz
+    sample = X_per_irrep[0]
+    nbasis_out = sample.shape[1]
+
+    k_sym_transform_ao = np.zeros((nk, nbasis_out, nbasis_out),
+                                  dtype=np.complex128)
+    tr_conj_bz = kstruct.time_reversal_symm_bz
+
+    if spinor:
+        nao = mycell.nao_nr()
+        theta = np.kron(np.array([[0, 1], [-1, 0]], dtype=np.complex128),
+                        np.eye(nao))
+
+    for ik in range(nk):
+        iop = stars_ops[ik]
+        if spinor:
+            u = get_spinor_representation(ik, iop, mycell, kstruct)
+            if tr_conj_bz[ik]:
+                u = (u @ theta).conj()
+        else:
+            u = get_representation(ik, iop, mycell, kstruct)
+        k_sym_transform_ao[ik] = u
+
+    return _propagate_with_reps(
+        X_per_irrep, Xinv_per_irrep,
+        kstruct.ibz2bz, kstruct.bz2ibz,
+        k_sym_transform_ao, tr_conj_bz,
+    )
+
+
+def build_X_kspace(
+    mode,
+    kstruct,
+    mycell,
+    S_ibz,
+    *,
+    F_ibz=None,
+    dm_ibz=None,
+    mo_coeff_ibz=None,
+    spinor=False,
+    tol_sing=1e-9,
+    tol_degen=1e-8,
+):
+    '''
+    Build orthogonalization matrices ``(X_k, X_inv_k)`` over the full BZ.
+
+    ``X`` is constructed only at IBZ k-points using one of the per-k
+    primitives, then propagated to every star member via the space-group
+    + time-reversal representations carried by ``kstruct``. See
+    ``_propagate_X_to_star`` for the convention.
+
+    Parameters
+    ----------
+    mode : {"lowdin", "mo", "natural"}
+        IBZ primitive to use.
+    kstruct : pyscf.pbc.lib.kpts.KPoints
+        Same object the rest of mbtools uses (e.g. from
+        ``kpt_utils.build_q_struct(mycell, kmesh, space_symm=True,
+        tr_symm=True)``).
+    mycell : pyscf.pbc.gto.Cell
+        Required for the AO-space representations.
+    S_ibz : (n_ibz, n, n) ndarray
+        Overlap at IBZ k-points, in the order
+        ``kstruct.kpts_scaled[kstruct.ibz2bz]``.
+    F_ibz : (n_ibz, n, n) ndarray, optional
+        Fock at IBZ. Required for ``mode="natural"`` (degeneracy
+        tie-breaking) and for ``mode="mo"`` when ``mo_coeff_ibz`` is not
+        provided (spin-averaged Fock is used to derive MOs).
+    dm_ibz : (n_ibz, n, n) ndarray, optional
+        Spin-averaged / total density matrix at IBZ. Required for
+        ``mode="natural"``.
+    mo_coeff_ibz : (n_ibz, n, n_mo) ndarray, optional
+        MO coefficients at IBZ. Preferred input for ``mode="mo"``.
+    spinor : bool, default False
+        If True, use the double-group spinor representation
+        (``get_spinor_representation``). Currently only supported with
+        ``mode="lowdin"``.
+    tol_sing : float
+        Threshold for discarding small eigenvalues of ``S`` in the
+        Löwdin primitive.
+    tol_degen : float
+        Tolerance used by the natural-mode Fock tie-breaker to detect
+        degenerate occupation blocks.
+
+    Returns
+    -------
+    X_k     : (nk, n_ortho, n) complex128 ndarray
+    X_inv_k : (nk, n,        n_ortho) complex128 ndarray
+    '''
+    if spinor and mode != "lowdin":
+        raise NotImplementedError(
+            f"build_X_kspace: spinor=True only supported for mode='lowdin', "
+            f"got mode={mode!r}."
+        )
+    if mode == "natural" and (dm_ibz is None or F_ibz is None):
+        raise ValueError(
+            "build_X_kspace: mode='natural' requires dm_ibz and F_ibz."
+        )
+    if mode == "mo" and mo_coeff_ibz is None and F_ibz is None:
+        raise ValueError(
+            "build_X_kspace: mode='mo' requires mo_coeff_ibz or F_ibz."
+        )
+
+    ibz2bz = kstruct.ibz2bz
+    n_ibz = len(ibz2bz)
+    S_ibz = np.asarray(S_ibz)
+    if S_ibz.shape[0] != n_ibz:
+        raise ValueError(
+            f"build_X_kspace: S_ibz has {S_ibz.shape[0]} k-points but "
+            f"kstruct has {n_ibz} IBZ points."
+        )
+
+    X_per_irrep, Xinv_per_irrep = _build_X_ibz(
+        mode, S_ibz, F_ibz, dm_ibz, mo_coeff_ibz, tol_sing, tol_degen
+    )
+
+    return _propagate_X_to_star(
+        X_per_irrep, Xinv_per_irrep, kstruct, mycell, spinor=spinor
+    )
+
+
+def build_X_kspace_from_ao_reps(
+    mode,
+    S_ibz,
+    ibz2bz,
+    bz2ibz,
+    k_sym_transform_ao,
+    *,
+    tr_conj=None,
+    F_ibz=None,
+    dm_ibz=None,
+    mo_coeff_ibz=None,
+    tol_sing=1e-9,
+    tol_degen=1e-8,
+):
+    '''
+    Build ``(X_k, X_inv_k)`` from precomputed AO-space rotations.
+
+    Identical to ``build_X_kspace`` but consumes the symmetry information
+    that ``common_utils.store_kstruct_ops_info`` already writes into
+    ``input.h5`` under ``/symmetry/k`` —
+
+      - ``ibz2bz``            (n_ibz,)        BZ indices of IBZ reps
+      - ``bz2ibz``            (nk,)           IBZ index for each BZ point
+      - ``k_sym_transform_ao``(nk, n, n)      stored AO rotation U(k)
+      - ``tr_conj``           (nk,)  bool     TR partner flags
+
+    — instead of (kstruct, mycell). Designed for callers like the SEET
+    pre-processor which read these arrays from h5 and do not carry a
+    PySCF ``KPoints`` object.
+
+    For non-TR points, ``M(k) = U M(k_ir) U†``; for TR points the stored
+    ``U`` already incorporates the conjugation factor (e.g. for X2C
+    double group, ``(U_spinor @ Θ).conj()``) and the reconstruction is
+    ``M(k) = (U M(k_ir) U†).conj()``. The function applies the matching
+    rule for X automatically — callers do not need to special-case TR.
+
+    Parameters mirror ``build_X_kspace``; ``mode`` semantics are
+    identical. ``spinor`` is implicit in the basis size of
+    ``S_ibz`` / ``k_sym_transform_ao`` (both are ``nso × nso`` for X2C).
+
+    Returns
+    -------
+    X_k     : (nk, n_ortho, n) complex128 ndarray
+    X_inv_k : (nk, n,        n_ortho) complex128 ndarray
+    '''
+    if mode == "natural" and (dm_ibz is None or F_ibz is None):
+        raise ValueError(
+            "build_X_kspace_from_ao_reps: mode='natural' requires "
+            "dm_ibz and F_ibz."
+        )
+    if mode == "mo" and mo_coeff_ibz is None and F_ibz is None:
+        raise ValueError(
+            "build_X_kspace_from_ao_reps: mode='mo' requires "
+            "mo_coeff_ibz or F_ibz."
+        )
+
+    ibz2bz_arr = np.asarray(ibz2bz)
+    n_ibz = ibz2bz_arr.shape[0]
+    S_ibz = np.asarray(S_ibz)
+    if S_ibz.shape[0] != n_ibz:
+        raise ValueError(
+            f"build_X_kspace_from_ao_reps: S_ibz has {S_ibz.shape[0]} "
+            f"k-points but ibz2bz has {n_ibz} entries."
+        )
+
+    X_per_irrep, Xinv_per_irrep = _build_X_ibz(
+        mode, S_ibz, F_ibz, dm_ibz, mo_coeff_ibz, tol_sing, tol_degen
+    )
+
+    return _propagate_with_reps(
+        X_per_irrep, Xinv_per_irrep,
+        ibz2bz_arr, np.asarray(bz2ibz),
+        np.asarray(k_sym_transform_ao, dtype=np.complex128),
+        np.asarray(tr_conj, dtype=bool) if tr_conj is not None else None,
+    )
 
 
 def symmetrical_orbitals(S, dm, F_up, F_dn, T_up, T_dn, kmesh, Debug_print=False):

--- a/green_mbtools/mint/ortho_utils.py
+++ b/green_mbtools/mint/ortho_utils.py
@@ -55,32 +55,51 @@ def mo_per_k(Sk, C_k):
     return C_k.conj().T, Sk @ C_k
 
 
+def _S_inv_half(Sk):
+    '''
+    Return ``S^{-1/2}`` via Hermitian eigendecomposition of S.
+    '''
+    s_ev, s_eb = np.linalg.eigh(Sk)
+    return (s_eb / np.sqrt(s_ev)) @ s_eb.conj().T
+
+
 def natural_per_k(Sk, dmk):
     '''
-    Natural-orbital basis for a single k-point from density matrix ``dmk``.
+    Natural-orbital basis at one k-point from density matrix ``dmk``.
 
-    Solves the generalized eigenproblem ``dm v = S^{-1} v n`` and returns
-    ``(X, X_inv)`` in the ``X Z X†`` convention such that
-    ``X_inv @ dm @ X_inv†`` is diagonal (occupations on the diagonal).
+    Diagonalises ``S^{-1/2} dm S^{-1/2}`` to obtain S-orthonormal
+    natural orbitals ``C_NO = S^{-1/2} u`` (columns) with
+    ``C_NO† S C_NO = I`` and ``C_NO† dm C_NO = diag(occ)``. Returns
+    ``(X, X_inv)`` in the same ``X Z X†`` convention as ``mo_per_k``:
+
+        X     = C_NO†      (shape (n_ortho, nao))
+        X_inv = S @ C_NO   (shape (nao, n_ortho))
     '''
-    _, Sv = LA.eigh(dmk, np.linalg.inv(Sk))
-    Sv = Sv.conj().T.astype(np.complex128)
-    return LA.inv(Sv), Sv
+    S_inv_half = _S_inv_half(Sk)
+    M = S_inv_half @ dmk @ S_inv_half
+    M = 0.5 * (M + M.conj().T)
+    _, u = np.linalg.eigh(M)
+    C_NO = (S_inv_half @ u).astype(np.complex128)
+    return C_NO.conj().T, Sk @ C_NO
 
 
 def _natural_per_k_with_fock_tiebreak(Sk, dmk, Fk, tol_degen=1e-8):
     '''
     Natural orbitals at one k-point with Fock-within-block tie-breaking.
 
-    Diagonalizes ``dmk`` against ``Sk`` to obtain occupations ``n`` and
-    eigenvectors ``V`` (columns) with ``V† S V = I``. Within each block
-    of columns whose occupations agree to ``tol_degen``, additionally
-    diagonalizes the block-projected Fock ``V_B† F V_B`` and rotates the
-    block accordingly. Returns ``(X, X_inv)`` in the ``X Z X†`` convention.
+    Same S-orthonormal convention as ``natural_per_k``: diagonalises
+    ``S^{-1/2} dm S^{-1/2}`` to obtain occupations and orbitals in the
+    ``S^{-1/2}`` frame, then for each block of columns whose occupations
+    agree to ``tol_degen`` additionally diagonalises the block-projected
+    AO Fock ``C_NO_B† F C_NO_B`` and rotates the block accordingly.
+    Returns ``(X = C_NO†, X_inv = S @ C_NO)``.
     '''
-    n_occ, V = LA.eigh(dmk, np.linalg.inv(Sk))
-    V = V.astype(np.complex128)
-    nbf = V.shape[1]
+    S_inv_half = _S_inv_half(Sk)
+    M = S_inv_half @ dmk @ S_inv_half
+    M = 0.5 * (M + M.conj().T)
+    n_occ, u = np.linalg.eigh(M)
+    u = u.astype(np.complex128)
+    nbf = u.shape[1]
 
     i = 0
     while i < nbf:
@@ -88,15 +107,16 @@ def _natural_per_k_with_fock_tiebreak(Sk, dmk, Fk, tol_degen=1e-8):
         while j < nbf and abs(n_occ[j] - n_occ[i]) < tol_degen:
             j += 1
         if j - i > 1:
-            VB = V[:, i:j]
-            FB = VB.conj().T @ Fk @ VB
+            uB = u[:, i:j]
+            C_NO_B = S_inv_half @ uB
+            FB = C_NO_B.conj().T @ Fk @ C_NO_B
             FB = 0.5 * (FB + FB.conj().T)
-            _, W = LA.eigh(FB)
-            V[:, i:j] = VB @ W
+            _, W = np.linalg.eigh(FB)
+            u[:, i:j] = uB @ W
         i = j
 
-    Vh = V.conj().T
-    return LA.inv(Vh), Vh
+    C_NO = (S_inv_half @ u).astype(np.complex128)
+    return C_NO.conj().T, Sk @ C_NO
 
 
 def _build_X_ibz(mode, S_ibz, F_ibz, dm_ibz, mo_coeff_ibz,

--- a/green_mbtools/mint/ortho_utils.py
+++ b/green_mbtools/mint/ortho_utils.py
@@ -36,19 +36,30 @@ def symmetric_lowdin_per_k(Sk, tol=1e-9):
     '''
     Symmetric (Hermitian) Löwdin orthogonalization for a single k-point.
 
-    Returns ``(X = S^{-1/2}, X_inv = S^{+1/2})`` — both Hermitian — in
-    the ``X Z X†`` convention. Distinguished from ``lowdin_per_k``,
-    which returns the *canonical* Löwdin form ``X = Λ^{-1/2} V†`` (a
-    different gauge on the orthogonal basis). Eigenvalues of ``Sk``
-    below ``tol`` are discarded; when linear dependencies are dropped
-    the result is rectangular like the canonical case.
+    Returns ``(X = S^{-1/2}, X_inv = S^{+1/2})`` — both Hermitian
+    ``(nao, nao)`` matrices — in the ``X Z X†`` convention.
+    Distinguished from ``lowdin_per_k`` (canonical Löwdin) by being
+    Hermitian rather than rectangular.
+
+    Eigenvalues of ``Sk`` below ``tol`` are treated pseudo-inversely:
+    their contribution is zeroed in both ``X`` and ``X_inv``, the same
+    convention ``LA.pinv`` applies (see ``pesto/orth.py``). The output
+    stays Hermitian and square, but in the rank-deficient case
+    ``X @ X_inv`` reduces to the projector onto the kept subspace
+    rather than the identity (Hermitian symmetric Löwdin cannot
+    simultaneously be a strict left inverse on a rank-deficient
+    basis). When linear dependencies are present and a strict
+    ``X @ X_inv = I`` contract is required, use ``lowdin_per_k``
+    (canonical, rectangular).
     '''
     s_ev, s_eb = np.linalg.eigh(Sk)
-    istart = s_ev.searchsorted(tol)
-    s_sqrt = np.sqrt(s_ev[istart:])
-    V = s_eb[:, istart:]
-    X = (V / s_sqrt) @ V.conj().T
-    X_inv = (V * s_sqrt) @ V.conj().T
+    kept = s_ev >= tol
+    s_sqrt = np.zeros_like(s_ev)
+    s_inv_sqrt = np.zeros_like(s_ev)
+    s_sqrt[kept] = np.sqrt(s_ev[kept])
+    s_inv_sqrt[kept] = 1.0 / np.sqrt(s_ev[kept])
+    X = (s_eb * s_inv_sqrt) @ s_eb.conj().T
+    X_inv = (s_eb * s_sqrt) @ s_eb.conj().T
     return X.astype(np.complex128), X_inv.astype(np.complex128)
 
 

--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -139,7 +139,17 @@ class pyscf_pbc_init (pyscf_init):
         X_k = []
         X_inv_k = []
 
-        # Orthogonalization matrix
+        # Orthogonalization matrix. For X2C (--x2c=2) the spinor S is
+        # block-diagonal in spin so Löwdin variants give a block-diagonal
+        # X whose AO block is a valid ERI rotation; MO and natural
+        # rotations would have non-block-diagonal X in general and are
+        # refused.
+        if self.args.x2c == 2 and self.args.orth not in ("none", "lowdin", "symmetric_lowdin"):
+            raise NotImplementedError(
+                "ortho not supported for 2-component / x2c1e calculations "
+                "with mode={!r}; allowed modes are 'none', 'lowdin', "
+                "'symmetric_lowdin'.".format(self.args.orth)
+            )
         X_k, X_inv_k, S, F, T, hf_dm = comm.orthogonalize(mydf, self.args.orth, X_k, X_inv_k, F, T, hf_dm, S, mf=mf)
         # Save data into Green Software package input format.
         comm.save_data(
@@ -435,7 +445,17 @@ class pyscf_mol_init (pyscf_init):
         X_k = []
         X_inv_k = []
 
-        # Orthogonalization matrix
+        # Orthogonalization matrix. For X2C (--x2c=2) the spinor S is
+        # block-diagonal in spin so Löwdin variants give a block-diagonal
+        # X whose AO block is a valid ERI rotation; MO and natural
+        # rotations would have non-block-diagonal X in general and are
+        # refused.
+        if self.args.x2c == 2 and self.args.orth not in ("none", "lowdin", "symmetric_lowdin"):
+            raise NotImplementedError(
+                "ortho not supported for 2-component / x2c1e calculations "
+                "with mode={!r}; allowed modes are 'none', 'lowdin', "
+                "'symmetric_lowdin'.".format(self.args.orth)
+            )
         X_k, X_inv_k, S, F, T, hf_dm = comm.orthogonalize(mydf, self.args.orth, X_k, X_inv_k, F, T, hf_dm, S, mf=mf)
         # Save data into Green Software package input format. Here we set Madelung constant to 0 as there is not long range divergence for molecule
         comm.save_data(self.args, self.kcell, mf, self.kmesh, self.ind, self.weight, self.num_ik, self.ir_list, self.conj_list, Nk, nk, NQ, F, S, T, hf_dm, 0.0, Zs, last_ao)

--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -195,11 +195,21 @@ class pyscf_pbc_init (pyscf_init):
             the Coulomb integrals are non-relativistic.
         X_k : list of ndarray
             Per-k-point orthogonalisation matrices X(k). The specific form
-            depends on ``args.orth``: Löwdin (``X(k) = S(k)^{-1/2}``),
-            canonical MOs (``X(k) = C(k)†``), or natural orbitals
-            (``X(k) = inv(Sv(k))``). When orthogonalisation is disabled
-            (``args.orth == "none"``), ``X_k`` contains identity transforms
-            for each k-point rather than an empty list.
+            depends on ``args.orth``:
+
+            * ``"lowdin"`` — canonical Löwdin, ``X(k) = Lambda^{-1/2} V†``
+              (rectangular when small eigenvalues of S are dropped).
+            * ``"symmetric_lowdin"`` — Hermitian Löwdin, ``X(k) = S(k)^{-1/2}``
+              (square; treats sub-tol eigenvalues pseudo-inversely).
+            * ``"mo"`` — canonical MOs, ``X(k) = C(k)†`` with
+              ``X_inv = S(k) @ C(k)``.
+            * ``"natural"`` — natural orbitals, ``X(k) = C_NO(k)†`` with
+              ``X_inv = S(k) @ C_NO(k)`` and ``C_NO`` the S-orthonormal
+              eigenvectors of ``S^{-1/2} dm S^{-1/2}``.
+
+            When orthogonalisation is disabled (``args.orth == "none"``),
+            ``X_k`` contains identity transforms for each k-point rather
+            than an empty list.
         '''
         # --- Step 1: mean-field integrals (bare Coulomb kernel) --------------
         mydf = comm.construct_gdf(self.args, self.cell, self.kmesh)

--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -210,7 +210,7 @@ class pyscf_pbc_init (pyscf_init):
         # GF2/GW corrections use a separate code path that handles the
         # correction internally; the plain Ewald correction is handled below.
         if 'gf2' in self.args.finite_size_kind or 'gw' in self.args.finite_size_kind or 'gw_s' in self.args.finite_size_kind:
-            self.compute_twobody_finitesize_correction()
+            self.compute_twobody_finitesize_correction(X_k=X_k)
             if not self.args.keep_cderi:
                 os.remove("cderi.h5")
                 os.system("sync")
@@ -277,12 +277,20 @@ class pyscf_pbc_init (pyscf_init):
         inp_data["high_symm_path/special_points"] = special_points
         inp_data["high_symm_path/special_labels"] = special_labels
 
-    def compute_twobody_finitesize_correction(self, mydf=None):
+    def compute_twobody_finitesize_correction(self, mydf=None, X_k=None):
         if not os.path.exists(self.args.hf_int_path):
             os.mkdir(self.args.hf_int_path)
         if 'gf2' in self.args.finite_size_kind :
-            comm.compute_ewald_correction(self.args, self.cell, self.kmesh, self.args.hf_int_path + "/df_ewald.h5")
+            comm.compute_ewald_correction(
+                self.args, self.cell, self.kmesh,
+                self.args.hf_int_path + "/df_ewald.h5",
+                X_k=X_k,
+            )
         if 'gw' in self.args.finite_size_kind :
+            # AqQ is a plane-wave ↔ aux-basis map with no AO indices, so it
+            # does not need the AO→ortho rotation that the Coulomb integrals
+            # require. The mbpt GW correction consumes AqQ together with the
+            # already-rotated V on disk.
             self.evaluate_gw_correction(mydf)
             
     

--- a/green_mbtools/mint/pyscf_init.py
+++ b/green_mbtools/mint/pyscf_init.py
@@ -107,7 +107,7 @@ class pyscf_pbc_init (pyscf_init):
         if self.args.grid_only:
             comm.store_k_grid(self.args, self.cell, self.kmesh, self.k_ibz, self.ir_list, self.conj_list, self.weight, self.ind, self.num_ik)
             auxcell = addons.make_auxmol(self.cell, mydf.auxbasis)
-            # NOTE: if args.orth = 1, we will not be able to transform the k_sym_transform_ao yet.
+            # NOTE: if args.orth != "none", we will not be able to transform the k_sym_transform_ao yet.
             comm.store_kstruct_ops_info(self.args, self.cell, self.kmesh, self.kstruct)
             comm.store_auxcell_kstruct_ops_info(self.args, auxcell, self.kmesh)
             return
@@ -140,7 +140,7 @@ class pyscf_pbc_init (pyscf_init):
         X_inv_k = []
 
         # Orthogonalization matrix
-        X_k, X_inv_k, S, F, T, hf_dm = comm.orthogonalize(mydf, self.args.orth, X_k, X_inv_k, F, T, hf_dm, S)
+        X_k, X_inv_k, S, F, T, hf_dm = comm.orthogonalize(mydf, self.args.orth, X_k, X_inv_k, F, T, hf_dm, S, mf=mf)
         # Save data into Green Software package input format.
         comm.save_data(
             self.args, self.cell, mf, self.kmesh, self.ind, self.weight, self.num_ik, self.ir_list, self.conj_list,
@@ -194,11 +194,12 @@ class pyscf_pbc_init (pyscf_init):
             Always ``cell.nao_nr()`` regardless of the X2C level, because
             the Coulomb integrals are non-relativistic.
         X_k : list of ndarray
-            Per-k-point orthogonalisation matrices X(k). For Löwdin
-            orthogonalisation, ``X(k) = S(k)^{-1/2}``. When
-            orthogonalisation is disabled (``args.orth == 0``), ``X_k``
-            contains identity transforms for each k-point rather than an
-            empty list.
+            Per-k-point orthogonalisation matrices X(k). The specific form
+            depends on ``args.orth``: Löwdin (``X(k) = S(k)^{-1/2}``),
+            canonical MOs (``X(k) = C(k)†``), or natural orbitals
+            (``X(k) = inv(Sv(k))``). When orthogonalisation is disabled
+            (``args.orth == "none"``), ``X_k`` contains identity transforms
+            for each k-point rather than an empty list.
         '''
         # --- Step 1: mean-field integrals (bare Coulomb kernel) --------------
         mydf = comm.construct_gdf(self.args, self.cell, self.kmesh)
@@ -417,7 +418,7 @@ class pyscf_mol_init (pyscf_init):
         X_inv_k = []
 
         # Orthogonalization matrix
-        X_k, X_inv_k, S, F, T, hf_dm = comm.orthogonalize(mydf, self.args.orth, X_k, X_inv_k, F, T, hf_dm, S)
+        X_k, X_inv_k, S, F, T, hf_dm = comm.orthogonalize(mydf, self.args.orth, X_k, X_inv_k, F, T, hf_dm, S, mf=mf)
         # Save data into Green Software package input format. Here we set Madelung constant to 0 as there is not long range divergence for molecule
         comm.save_data(self.args, self.kcell, mf, self.kmesh, self.ind, self.weight, self.num_ik, self.ir_list, self.conj_list, Nk, nk, NQ, F, S, T, hf_dm, 0.0, Zs, last_ao)
         comm.store_mol_symmetry_info(self.args, self.kcell, auxcell, self.kmesh)

--- a/green_mbtools/mint/seet_init.py
+++ b/green_mbtools/mint/seet_init.py
@@ -68,33 +68,26 @@ class seet_init:
         dm    = (dm[0] + dm[1])*0.5
         gf2_inp_data.close()
 
-        e_nuc           = inp_data["HF/Energy_nuc"][()]
-        nk              = inp_data["HF/nk"][()]
         kmesh           = inp_data["grid/k_mesh"][()]
         kmesh_sc        = inp_data["grid/k_mesh_scaled"][()]
-        reduced_mesh    = inp_data["grid/k_mesh"][()]
-        reduced_mesh_sc = inp_data["grid/k_mesh_scaled"][()]
-        if "grid/weight" in inp_data:
-            weight          = inp_data["grid/weight"][()]
-            conj_list       = inp_data["grid/conj_list"][()]
-            ir_list = inp_data["grid/ir_list"][()]
-            bz_index = inp_data["grid/index"][()]
-        else:
-            weight = [1] * kmesh.shape[0]
-            conj_list = [0] * kmesh.shape[0]
-            ir_list = range(kmesh.shape[0])
-            bz_index = range(kmesh.shape[0])
         S     = inp_data["HF/S-k"][()].view(np.complex128)
         S     = S.reshape(S.shape[:-1])
         T     = inp_data["HF/H-k"][()].view(np.complex128)
         T     = T.reshape(T.shape[:-1])
         if self.args.from_ibz:
-            # T = to_full_bz(T, conj_list, ir_list, bz_index, 1)
-            S1 = self.to_full_bz(S1, conj_list, ir_list, bz_index, 1)
+            if "grid/weight" in inp_data:
+                conj_list = inp_data["grid/conj_list"][()]
+                ir_list   = inp_data["grid/ir_list"][()]
+                bz_index  = inp_data["grid/index"][()]
+            else:
+                conj_list = [0] * kmesh.shape[0]
+                ir_list   = range(kmesh.shape[0])
+                bz_index  = range(kmesh.shape[0])
+            S1   = self.to_full_bz(S1, conj_list, ir_list, bz_index, 1)
             dm_s = self.to_full_bz(dm_s, conj_list, ir_list, bz_index, 1)
-            dm = self.to_full_bz(dm, conj_list, ir_list, bz_index, 0)
+            dm   = self.to_full_bz(dm, conj_list, ir_list, bz_index, 0)
 
         inp_data.close()
         F = S1 + T
 
-        return F, S, T, dm, dm_s, e_nuc, nk, kmesh, kmesh_sc, reduced_mesh, reduced_mesh_sc, weight, conj_list, ir_list, bz_index
+        return F, S, T, dm, dm_s, kmesh, kmesh_sc

--- a/tests/ortho_utils_kspace_test.py
+++ b/tests/ortho_utils_kspace_test.py
@@ -1,0 +1,487 @@
+"""Tests for the kstruct-driven full-BZ orthogonalization layer in
+``green_mbtools.mint.ortho_utils``.
+
+These cover the new ``build_X_kspace`` and ``_natural_per_k_with_fock_tiebreak``
+helpers introduced by the orthofix work. The per-k primitives
+(``lowdin_per_k``, ``mo_per_k``, ``natural_per_k``) are tested separately in
+``ortho_utils_test.py``.
+"""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+import scipy.linalg as LA
+
+from green_mbtools.mint import ortho_utils
+from green_mbtools.mint.ortho_utils import (
+    build_X_kspace,
+    build_X_kspace_from_ao_reps,
+    _natural_per_k_with_fock_tiebreak,
+)
+
+
+_TOL = 1e-9
+
+
+def _build_h2_cell_and_kstruct(nk=3, space_symm=True, tr_symm=True):
+    """Build a small H2 PBC cell and a kstruct on an nk×nk×nk mesh."""
+    from pyscf.pbc import gto as pbc_gto
+    from green_mbtools.mint.kpt_utils import build_q_struct
+
+    cell = pbc_gto.Cell()
+    cell.atom = "H -0.25 -0.25 -0.25\nH  0.25  0.25  0.25"
+    cell.a = np.array([[4.0655, 0.0, 0.0],
+                       [0.0, 4.0655, 0.0],
+                       [0.0, 0.0, 4.0655]])
+    cell.basis = "gth-dzvp-molopt-sr"
+    cell.pseudo = "gth-pbe"
+    cell.unit = "Angstrom"
+    cell.verbose = 0
+    cell.build()
+
+    kpts = cell.make_kpts([nk, nk, nk])
+    kstruct = build_q_struct(cell, kpts, space_symm=space_symm, tr_symm=tr_symm)
+    return cell, kstruct
+
+
+def _per_k_overlap(cell, kstruct):
+    """Return S(k) at every BZ k-point of kstruct."""
+    return cell.pbc_intor("int1e_ovlp", kpts=kstruct.kpts)
+
+
+@pytest.fixture(scope="module")
+def h2_setup():
+    cell, kstruct = _build_h2_cell_and_kstruct(nk=3, space_symm=True, tr_symm=True)
+    S_bz = np.asarray(_per_k_overlap(cell, kstruct))
+    S_ibz = S_bz[kstruct.ibz2bz]
+    return {
+        "cell": cell,
+        "kstruct": kstruct,
+        "S_bz": S_bz,
+        "S_ibz": S_ibz,
+    }
+
+
+def test_lowdin_kspace_representation_contract(h2_setup):
+    """X(k) S(k) X(k)† = I at every BZ point, X built only at IBZ."""
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_bz = h2_setup["S_bz"]
+    S_ibz = h2_setup["S_ibz"]
+
+    X_k, X_inv_k = build_X_kspace(
+        "lowdin", kstruct, cell, S_ibz
+    )
+
+    nk = kstruct.nkpts
+    assert X_k.shape[0] == nk
+    assert X_inv_k.shape[0] == nk
+
+    n_ortho = X_k.shape[1]
+    eye = np.eye(n_ortho, dtype=np.complex128)
+
+    for ik in range(nk):
+        prod = X_k[ik] @ S_bz[ik] @ X_k[ik].conj().T
+        np.testing.assert_allclose(
+            prod, eye, atol=1e-9, rtol=0,
+            err_msg=f"Löwdin orthogonality fails at BZ k={ik}",
+        )
+        prod2 = X_k[ik] @ X_inv_k[ik]
+        np.testing.assert_allclose(
+            prod2, eye, atol=1e-9, rtol=0,
+            err_msg=f"X @ X_inv != I at BZ k={ik}",
+        )
+
+
+def test_kspace_propagation_uses_kstruct_ordering(h2_setup):
+    """build_X_kspace output ordering matches kstruct.kpts order one-to-one."""
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+
+    X_k, _ = build_X_kspace("lowdin", kstruct, cell, S_ibz)
+
+    # At each IBZ representative position, X should equal the per-k Löwdin
+    # result on S_ibz directly (no rotation, because the IBZ point is in
+    # its own little group's identity slot).
+    for i_ir, ik_ir in enumerate(kstruct.ibz2bz):
+        x_ref, _ = ortho_utils.lowdin_per_k(S_ibz[i_ir])
+        # Gauge: at IBZ rep, stars_ops should map the rep to itself via U=I
+        # (modulo phase). Compare X X† to identify with the reference up to
+        # a unitary on the right — but for the identity op specifically
+        # they must match bitwise via the formula X(k_ir) = X_ir @ I.
+        np.testing.assert_allclose(
+            X_k[ik_ir], x_ref, atol=1e-9, rtol=0,
+            err_msg=(
+                f"At IBZ rep BZ-index {ik_ir} (ibz idx {i_ir}), "
+                "build_X_kspace does not return the per-k Löwdin result"
+            ),
+        )
+
+
+def test_lowdin_kspace_orthogonalizes_fock(h2_setup):
+    """X(k) F(k) X_inv(k) is gauge-invariant across the star and Hermitian."""
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_bz = h2_setup["S_bz"]
+    S_ibz = h2_setup["S_ibz"]
+    rng = np.random.default_rng(20260610)
+
+    # Build a symmetry-respecting Fock by propagating a random IBZ Fock to
+    # the full BZ via the same representations build_X_kspace uses.
+    from green_mbtools.mint.symmetry_utils import get_representation
+
+    nao = cell.nao_nr()
+    F_ibz = np.zeros((len(kstruct.ibz2bz), nao, nao), dtype=np.complex128)
+    for i_ir in range(len(kstruct.ibz2bz)):
+        A = rng.standard_normal((nao, nao)) + 1j * rng.standard_normal((nao, nao))
+        F_ibz[i_ir] = 0.5 * (A + A.conj().T)
+
+    F_bz = np.zeros((kstruct.nkpts, nao, nao), dtype=np.complex128)
+    bz2ibz_bz = kstruct.ibz2bz[kstruct.bz2ibz]
+    ir_pos = {int(k): i for i, k in enumerate(kstruct.ibz2bz)}
+    for ik in range(kstruct.nkpts):
+        ik_ir = bz2ibz_bz[ik]
+        u = get_representation(ik, kstruct.stars_ops_bz[ik], cell, kstruct)
+        F_bz[ik] = u @ F_ibz[ir_pos[int(ik_ir)]] @ u.conj().T
+
+    X_k, X_inv_k = build_X_kspace("lowdin", kstruct, cell, S_ibz)
+
+    # X F X_inv must equal the IBZ-frame quantity X_ir F_ir X_inv_ir for all
+    # star members.
+    F_ortho_ref = {}
+    for i_ir, ik_ir in enumerate(kstruct.ibz2bz):
+        F_ortho_ref[int(ik_ir)] = X_k[ik_ir] @ F_bz[ik_ir] @ X_inv_k[ik_ir]
+
+    for ik in range(kstruct.nkpts):
+        ik_ir = int(bz2ibz_bz[ik])
+        prod = X_k[ik] @ F_bz[ik] @ X_inv_k[ik]
+        np.testing.assert_allclose(
+            prod, F_ortho_ref[ik_ir], atol=1e-9, rtol=0,
+            err_msg=f"Gauge invariance broken at BZ k={ik} (ibz rep {ik_ir})",
+        )
+
+
+def test_natural_per_k_fock_tiebreak_deterministic_in_degenerate_block():
+    """NO tie-breaker yields a deterministic basis when occupations degenerate."""
+    n = 6
+    rng = np.random.default_rng(42)
+
+    # S = I keeps the generalized eigenproblem in standard form so the
+    # degeneracy structure of dm is straightforward to control.
+    S = np.eye(n, dtype=np.complex128)
+
+    n_occ = np.array([2.0, 2.0, 1.5, 1.0, 0.5, 0.1])
+    V0 = rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n))
+    V0, _ = np.linalg.qr(V0)
+    dm = V0 @ np.diag(n_occ) @ V0.conj().T
+    dm = 0.5 * (dm + dm.conj().T)
+
+    A = rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n))
+    F = 0.5 * (A + A.conj().T)
+
+    X1, X_inv1 = _natural_per_k_with_fock_tiebreak(S, dm, F)
+    X2, X_inv2 = _natural_per_k_with_fock_tiebreak(S, dm, F)
+
+    np.testing.assert_allclose(X1, X2, atol=0, rtol=0,
+        err_msg="NO tie-breaker is not bitwise deterministic")
+    np.testing.assert_allclose(X_inv1, X_inv2, atol=0, rtol=0)
+
+    # X X_inv = I
+    np.testing.assert_allclose(X1 @ X_inv1, np.eye(n), atol=1e-10)
+
+    # Columns of X_inv are S-orthonormal: X_inv† S X_inv = I (with S=I)
+    np.testing.assert_allclose(
+        X_inv1.conj().T @ S @ X_inv1, np.eye(n), atol=1e-9,
+    )
+
+    # Within the originally-degenerate block (occupations both = 2.0), the
+    # Fock projected onto the block must be diagonal in the new basis.
+    # LA.eigh returns eigenvalues in ascending order, so the two
+    # max-occupation columns sit at the end of V; X_inv = V† so the
+    # corresponding *rows* of X_inv are the conjugated natural orbitals.
+    deg_rows = [n - 2, n - 1]
+    V_B = X_inv1[deg_rows, :].conj().T   # (n, 2) natural orbitals
+    FB = V_B.conj().T @ F @ V_B
+    off = FB - np.diag(np.diag(FB))
+    assert np.max(np.abs(off)) < 1e-8, (
+        f"Fock not diagonalized within degenerate block: |off|={np.max(np.abs(off))}"
+    )
+
+
+def test_natural_mode_requires_dm_and_F(h2_setup):
+    """build_X_kspace mode='natural' raises without dm_ibz or F_ibz."""
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+
+    with pytest.raises(ValueError):
+        build_X_kspace("natural", kstruct, cell, S_ibz)
+    with pytest.raises(ValueError):
+        build_X_kspace("natural", kstruct, cell, S_ibz, dm_ibz=S_ibz)
+
+
+def test_mo_mode_requires_C_or_F(h2_setup):
+    """build_X_kspace mode='mo' raises without mo_coeff_ibz or F_ibz."""
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+
+    with pytest.raises(ValueError):
+        build_X_kspace("mo", kstruct, cell, S_ibz)
+
+
+def test_unknown_mode_raises(h2_setup):
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+    with pytest.raises(ValueError):
+        build_X_kspace("bogus", kstruct, cell, S_ibz)
+
+
+def test_spinor_only_with_lowdin(h2_setup):
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+    with pytest.raises(NotImplementedError):
+        build_X_kspace("mo", kstruct, cell, S_ibz, spinor=True,
+                       mo_coeff_ibz=np.zeros_like(S_ibz))
+
+
+def test_from_ao_reps_matches_kstruct_path(h2_setup):
+    """build_X_kspace_from_ao_reps with reps extracted from kstruct
+    reproduces build_X_kspace output bit-for-bit."""
+    from green_mbtools.mint.symmetry_utils import get_representation
+
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+
+    # Reference: kstruct-driven path
+    X_ref, X_inv_ref = build_X_kspace("lowdin", kstruct, cell, S_ibz)
+
+    # Precompute AO reps the way store_kstruct_ops_info does for non-X2C.
+    nk = kstruct.nkpts
+    nao = cell.nao_nr()
+    k_sym = np.zeros((nk, nao, nao), dtype=np.complex128)
+    for ik in range(nk):
+        k_sym[ik] = get_representation(
+            ik, kstruct.stars_ops_bz[ik], cell, kstruct
+        )
+    tr_conj = np.asarray(kstruct.time_reversal_symm_bz, dtype=bool)
+
+    X_alt, X_inv_alt = build_X_kspace_from_ao_reps(
+        "lowdin", S_ibz, kstruct.ibz2bz, kstruct.bz2ibz, k_sym,
+        tr_conj=tr_conj,
+    )
+
+    np.testing.assert_allclose(X_alt, X_ref, atol=1e-12, rtol=0)
+    np.testing.assert_allclose(X_inv_alt, X_inv_ref, atol=1e-12, rtol=0)
+
+
+def test_from_ao_reps_orthogonalizes_S(h2_setup):
+    """build_X_kspace_from_ao_reps output satisfies X(k) S(k) X(k)† = I."""
+    from green_mbtools.mint.symmetry_utils import get_representation
+
+    cell = h2_setup["cell"]
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+    S_bz = h2_setup["S_bz"]
+
+    nk = kstruct.nkpts
+    nao = cell.nao_nr()
+    k_sym = np.zeros((nk, nao, nao), dtype=np.complex128)
+    for ik in range(nk):
+        k_sym[ik] = get_representation(
+            ik, kstruct.stars_ops_bz[ik], cell, kstruct
+        )
+    tr_conj = np.asarray(kstruct.time_reversal_symm_bz, dtype=bool)
+
+    X_k, _ = build_X_kspace_from_ao_reps(
+        "lowdin", S_ibz, kstruct.ibz2bz, kstruct.bz2ibz, k_sym,
+        tr_conj=tr_conj,
+    )
+
+    n_ortho = X_k.shape[1]
+    eye = np.eye(n_ortho, dtype=np.complex128)
+    for ik in range(nk):
+        np.testing.assert_allclose(
+            X_k[ik] @ S_bz[ik] @ X_k[ik].conj().T, eye, atol=1e-9,
+            err_msg=f"X S X† != I at BZ k={ik} (from_ao_reps path)",
+        )
+
+
+def test_from_ao_reps_natural_requires_inputs(h2_setup):
+    kstruct = h2_setup["kstruct"]
+    S_ibz = h2_setup["S_ibz"]
+    nk = kstruct.nkpts
+    n = S_ibz.shape[1]
+    fake_reps = np.tile(np.eye(n, dtype=np.complex128), (nk, 1, 1))
+    with pytest.raises(ValueError):
+        build_X_kspace_from_ao_reps(
+            "natural", S_ibz, kstruct.ibz2bz, kstruct.bz2ibz, fake_reps
+        )
+
+
+@pytest.fixture(scope="module")
+def h2_tr_only_setup():
+    """H2 cubic cell with TR-only k-reduction (space_symm=False).
+
+    Built specifically so that BZ stars are pure TR pairs ``(k, -k)`` and
+    every TR partner has ``time_reversal_symm_bz[ik] = True``. The
+    centrosymmetric default fixture sweeps TR into spatial inversion and
+    never exercises the TR-conjugation branch of build_X_kspace_from_ao_reps.
+    """
+    cell, kstruct = _build_h2_cell_and_kstruct(
+        nk=3, space_symm=False, tr_symm=True
+    )
+    S_bz = np.asarray(_per_k_overlap(cell, kstruct))
+    S_ibz = S_bz[kstruct.ibz2bz]
+    return {"cell": cell, "kstruct": kstruct, "S_bz": S_bz, "S_ibz": S_ibz}
+
+
+def _tr_partner_indices(cell, kstruct):
+    """Return ``tr_of[ik]`` = BZ index of the TR partner of BZ point ``ik``."""
+    scaled = cell.get_scaled_kpts(kstruct.kpts)
+    nk = scaled.shape[0]
+    tr_of = np.full(nk, -1, dtype=int)
+    for ik in range(nk):
+        target = -scaled[ik]
+        for jk in range(nk):
+            diff = scaled[jk] - target
+            diff -= np.round(diff)
+            if np.max(np.abs(diff)) < 1e-8:
+                tr_of[ik] = jk
+                break
+    assert np.all(tr_of >= 0), "Could not locate TR partner for every k-point"
+    return tr_of
+
+
+def test_itransform_tr_identity_with_new_X(h2_tr_only_setup):
+    """Regression: the V-rotation TR identity that itransform.cpp's
+    ``conj_kpair_list`` shortcut relies on holds under the new
+    full-BZ X built by build_X_kspace_from_ao_reps + legacy-storage shim.
+
+    For every TR-paired kpair, with V_AO satisfying
+    ``V_AO(-ki, -kj) = V_AO(ki, kj).conj()`` (the real-AO inversion rule),
+    requires the orthogonalized V to satisfy
+    ``V_ortho(-ki, -kj) = V_ortho(ki, kj).conj()`` after applying
+    ``X_legacy(ki).adjoint() @ V_AO @ X_legacy(kj)``.
+
+    Without this property, itransform.cpp would silently produce the
+    wrong V_ortho at TR-paired kpairs.
+    """
+    from green_mbtools.mint.symmetry_utils import get_representation
+    from green_mbtools.mint.ortho_utils import build_X_kspace_from_ao_reps
+
+    cell = h2_tr_only_setup["cell"]
+    kstruct = h2_tr_only_setup["kstruct"]
+    S_ibz = h2_tr_only_setup["S_ibz"]
+
+    # Sanity check that the fixture actually exercises TR: at least one
+    # BZ point must have time_reversal_symm_bz=True.
+    tr_conj_bz = np.asarray(kstruct.time_reversal_symm_bz, dtype=bool)
+    assert tr_conj_bz.any(), (
+        "h2_tr_only fixture didn't produce any TR-paired k-points — "
+        "test would not exercise the TR branch"
+    )
+
+    # Precompute AO reps and run the new path.
+    nk = kstruct.nkpts
+    nao = cell.nao_nr()
+    k_sym_ao = np.zeros((nk, nao, nao), dtype=np.complex128)
+    for ik in range(nk):
+        k_sym_ao[ik] = get_representation(
+            ik, kstruct.stars_ops_bz[ik], cell, kstruct
+        )
+    X_k_new, X_inv_k_new = build_X_kspace_from_ao_reps(
+        "lowdin", S_ibz, kstruct.ibz2bz, kstruct.bz2ibz, k_sym_ao,
+        tr_conj=tr_conj_bz,
+    )
+
+    # Apply the same legacy-storage shim init_seet.py uses before
+    # writing to transform.h5.
+    X_legacy = X_k_new.conj().swapaxes(1, 2)
+
+    # Build a synthetic V_AO(k, k') over the full BZ that respects the
+    # real-AO inversion identity V_AO(-k, -k') = V_AO(k, k').conj().
+    # The simplest construction: pick V_AO independently at each
+    # (ki, kj) where ki <= kj in some ordering that contains no TR
+    # partners, then fill the conjugate-partner entries.
+    rng = np.random.default_rng(20260611)
+    V_AO = np.zeros((nk, nk, nao, nao), dtype=np.complex128)
+    tr_of = _tr_partner_indices(cell, kstruct)
+    assigned = np.zeros((nk, nk), dtype=bool)
+    for ki in range(nk):
+        for kj in range(nk):
+            if assigned[ki, kj]:
+                continue
+            kti = tr_of[ki]
+            ktj = tr_of[kj]
+            if (kti, ktj) == (ki, kj):
+                # Self-TR-paired kpair: identity forces V to be real.
+                A = rng.standard_normal((nao, nao)).astype(np.complex128)
+            else:
+                A = (rng.standard_normal((nao, nao))
+                     + 1j * rng.standard_normal((nao, nao)))
+                V_AO[kti, ktj] = A.conj()
+                assigned[kti, ktj] = True
+            V_AO[ki, kj] = A
+            assigned[ki, kj] = True
+
+    # Verify the V_AO identity we constructed.
+    for ki in range(nk):
+        for kj in range(nk):
+            np.testing.assert_allclose(
+                V_AO[tr_of[ki], tr_of[kj]], V_AO[ki, kj].conj(),
+                atol=1e-12,
+                err_msg=f"V_AO TR identity broken at constructed ({ki},{kj})",
+            )
+
+    # The actual check: V_ortho satisfies the same TR identity, which
+    # is exactly what itransform.cpp's conj_kpair_list reduction
+    # assumes.
+    for ki in range(nk):
+        for kj in range(nk):
+            kti = tr_of[ki]
+            ktj = tr_of[kj]
+            V_ortho_ij = (X_legacy[ki].conj().T @ V_AO[ki, kj]
+                          @ X_legacy[kj])
+            V_ortho_tr = (X_legacy[kti].conj().T @ V_AO[kti, ktj]
+                          @ X_legacy[ktj])
+            np.testing.assert_allclose(
+                V_ortho_tr, V_ortho_ij.conj(), atol=1e-9, rtol=0,
+                err_msg=(
+                    f"V_ortho TR identity broken at kpair ({ki},{kj}) "
+                    f"vs TR partner ({kti},{ktj}). "
+                    "itransform.cpp's conj_kpair_list shortcut would "
+                    "produce wrong V_ortho here."
+                ),
+            )
+
+
+def test_ar_x2c_spinor_orthogonality():
+    """Lowdin in the X2C double group orthogonalizes S(k) at every BZ point."""
+    data_file = Path(__file__).parent / "test_data" / "Ar_x2c" / "input_full_symm.h5"
+    if not data_file.exists():
+        pytest.skip("Ar X2C reference data not available")
+
+    with h5py.File(data_file, "r") as f:
+        S_raw = f["HF/S-k"][()]
+        bz2ibz = f["symmetry/k/bz2ibz"][()]
+        nk = int(f["symmetry/k/nk"][()])
+    S_bz = S_raw.view(complex).reshape(S_raw.shape[:-1])
+    # (ns, nk, nso, nso) -> use spin 0
+    if S_bz.ndim == 4:
+        S_bz = S_bz[0]
+    assert S_bz.shape[0] == nk
+
+    # Build kstruct + cell for Ar X2C from the input file's params (the cell
+    # must match the one used to generate the reference); if those params are
+    # not in the file we skip the spinor end-to-end test.
+    pytest.skip(
+        "Spinor end-to-end test needs the original Ar cell parameters; "
+        "covered by the AO-rep test in symmetry_test.py for now."
+    )

--- a/tests/ortho_utils_kspace_test.py
+++ b/tests/ortho_utils_kspace_test.py
@@ -192,19 +192,20 @@ def test_natural_per_k_fock_tiebreak_deterministic_in_degenerate_block():
     # X X_inv = I
     np.testing.assert_allclose(X1 @ X_inv1, np.eye(n), atol=1e-10)
 
-    # Columns of X_inv are S-orthonormal: X_inv† S X_inv = I (with S=I)
+    # X orthogonalises S: X S X† = I  (mo_per_k convention)
     np.testing.assert_allclose(
-        X_inv1.conj().T @ S @ X_inv1, np.eye(n), atol=1e-9,
+        X1 @ S @ X1.conj().T, np.eye(n), atol=1e-9,
     )
 
     # Within the originally-degenerate block (occupations both = 2.0), the
     # Fock projected onto the block must be diagonal in the new basis.
-    # LA.eigh returns eigenvalues in ascending order, so the two
-    # max-occupation columns sit at the end of V; X_inv = V† so the
-    # corresponding *rows* of X_inv are the conjugated natural orbitals.
+    # eigh returns eigenvalues in ascending order, so the two
+    # max-occupation columns sit at the end; X = C_NO† so the corresponding
+    # *rows* of X are the conjugated natural orbitals — pull them as columns
+    # by transposing back.
     deg_rows = [n - 2, n - 1]
-    V_B = X_inv1[deg_rows, :].conj().T   # (n, 2) natural orbitals
-    FB = V_B.conj().T @ F @ V_B
+    C_NO_B = X1[deg_rows, :].conj().T   # (n, 2) natural orbitals
+    FB = C_NO_B.conj().T @ F @ C_NO_B
     off = FB - np.diag(np.diag(FB))
     assert np.max(np.abs(off)) < 1e-8, (
         f"Fock not diagonalized within degenerate block: |off|={np.max(np.abs(off))}"

--- a/tests/ortho_utils_test.py
+++ b/tests/ortho_utils_test.py
@@ -96,15 +96,13 @@ def test_natural_per_k_diagonalizes_dm(rng):
 
     X, X_inv = ortho_utils.natural_per_k(S, dm)
 
-    # left-inverse
+    # left-inverse and S-orthogonalisation
     assert np.allclose(X @ X_inv, np.eye(n), atol=_TOL)
-    # X_inv dm X_inv†  is diagonal (NO occupations on diagonal)
-    D = X_inv @ dm @ X_inv.conj().T
+    assert np.allclose(X @ S @ X.conj().T, np.eye(n), atol=_TOL)
+    # X dm X†  is diagonal (NO occupations on diagonal in the operator
+    # convention; mirrors mo_per_k's shape contract X = C_NO†, X_inv = S·C_NO)
+    D = X @ dm @ X.conj().T
     assert np.allclose(D, np.diag(np.diag(D)), atol=_TOL)
-    # the eigh(dm, S^{-1}) formulation gives V s.t. V† S^{-1} V = I,
-    # i.e. X_inv @ inv(S) @ X_inv† = I  (not X S X†)
-    S_inv = np.linalg.inv(S)
-    assert np.allclose(X_inv @ S_inv @ X_inv.conj().T, np.eye(n), atol=_TOL)
 
 
 def test_helpers_return_complex128(rng):

--- a/tests/ortho_utils_test.py
+++ b/tests/ortho_utils_test.py
@@ -67,6 +67,49 @@ def test_lowdin_per_k_drops_small_eigenvalues(rng):
     assert np.allclose(X @ X_inv, np.eye(n - 1), atol=_TOL)
 
 
+@pytest.mark.parametrize("n", [1, 4, 7])
+def test_symmetric_lowdin_per_k_hermitian_full_rank(rng, n):
+    S = _hermitian_pd(rng, n)
+    X, X_inv = ortho_utils.symmetric_lowdin_per_k(S)
+
+    # Both factors are Hermitian and full square.
+    assert X.shape == (n, n)
+    assert X_inv.shape == (n, n)
+    assert np.allclose(X, X.conj().T, atol=_TOL)
+    assert np.allclose(X_inv, X_inv.conj().T, atol=_TOL)
+
+    # X X_inv = I (left-inverse) and X S X† = I (orthogonalises S).
+    assert np.allclose(X @ X_inv, np.eye(n), atol=_TOL)
+    assert np.allclose(X @ S @ X.conj().T, np.eye(n), atol=_TOL)
+
+    # X_inv X_inv† = S (X_inv = S^{1/2}).
+    assert np.allclose(X_inv @ X_inv.conj().T, S, atol=_TOL)
+
+
+def test_symmetric_lowdin_per_k_rank_deficient_pseudoinverse(rng):
+    # S with one eigenvalue below tol: symmetric Löwdin should treat the
+    # mode pseudo-inversely (zero it out) so the output stays Hermitian and
+    # finite. X @ X_inv reduces to the projector onto the kept subspace.
+    n = 5
+    U, _ = np.linalg.qr(rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n)))
+    evals = np.array([1e-12, 0.5, 1.0, 2.0, 3.0])
+    S = U @ np.diag(evals) @ U.conj().T
+    S = 0.5 * (S + S.conj().T)
+
+    X, X_inv = ortho_utils.symmetric_lowdin_per_k(S, tol=1e-9)
+    # Outputs are still square Hermitian and finite.
+    assert X.shape == (n, n)
+    assert X_inv.shape == (n, n)
+    assert np.isfinite(X).all() and np.isfinite(X_inv).all()
+    assert np.allclose(X, X.conj().T, atol=_TOL)
+    assert np.allclose(X_inv, X_inv.conj().T, atol=_TOL)
+    # X @ X_inv is the projector onto the kept (n-1)-dim subspace.
+    P = X @ X_inv
+    # Idempotent (P @ P = P) and rank n-1.
+    assert np.allclose(P @ P, P, atol=_TOL)
+    assert np.linalg.matrix_rank(P, tol=1e-7) == n - 1
+
+
 def test_mo_per_k_diagonalizes_fock(rng):
     n = 6
     S = _hermitian_pd(rng, n)

--- a/tests/ortho_utils_test.py
+++ b/tests/ortho_utils_test.py
@@ -1,0 +1,123 @@
+"""Tests for the per-k orthogonalization helpers in ``green_mbtools.mint.ortho_utils``.
+
+These cover the small building blocks used by ``common_utils.orthogonalize``:
+    - ``lowdin_per_k``  : symmetric S^{-1/2} orthogonalization
+    - ``mo_per_k``      : canonical-MO basis from supplied C(k)
+    - ``natural_per_k`` : natural-orbital basis from a density matrix
+All helpers return ``(X, X_inv)`` in the ``X Z X†`` convention used by
+``common_utils.transform``.
+"""
+
+import numpy as np
+import pytest
+import scipy.linalg as LA
+
+from green_mbtools.mint import ortho_utils
+
+
+_TOL = 1e-10
+
+
+def _hermitian_pd(rng, n, shift=None):
+    """Build a random Hermitian positive-definite matrix of size n."""
+    A = rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n))
+    M = A.conj().T @ A
+    if shift is None:
+        shift = n
+    M = M + shift * np.eye(n)
+    return 0.5 * (M + M.conj().T)
+
+
+def _hermitian(rng, n):
+    """Build a random Hermitian matrix of size n."""
+    A = rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n))
+    return 0.5 * (A + A.conj().T)
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(20260609)
+
+
+@pytest.mark.parametrize("n", [1, 4, 7])
+def test_lowdin_per_k_orthogonalizes_S(rng, n):
+    S = _hermitian_pd(rng, n)
+    X, X_inv = ortho_utils.lowdin_per_k(S)
+
+    # X X_inv = I  (left-inverse)
+    assert np.allclose(X @ X_inv, np.eye(n), atol=_TOL)
+    # X S X† = I  (Löwdin orthogonalizes S)
+    assert np.allclose(X @ S @ X.conj().T, np.eye(n), atol=_TOL)
+    # X_inv = S^{1/2} reconstructs S:  X_inv X_inv† = S
+    assert np.allclose(X_inv @ X_inv.conj().T, S, atol=_TOL)
+
+
+def test_lowdin_per_k_drops_small_eigenvalues(rng):
+    # Build S with one near-zero eigenvalue; expect rectangular output.
+    n = 5
+    U, _ = np.linalg.qr(rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n)))
+    evals = np.array([1e-12, 0.5, 1.0, 2.0, 3.0])
+    S = U @ np.diag(evals) @ U.conj().T
+    S = 0.5 * (S + S.conj().T)
+
+    X, X_inv = ortho_utils.lowdin_per_k(S, tol=1e-9)
+    # one mode dropped → X has shape (n-1, n)
+    assert X.shape == (n - 1, n)
+    assert X_inv.shape == (n, n - 1)
+    assert np.allclose(X @ X_inv, np.eye(n - 1), atol=_TOL)
+
+
+def test_mo_per_k_diagonalizes_fock(rng):
+    n = 6
+    S = _hermitian_pd(rng, n)
+    F = _hermitian(rng, n)
+    eps, C = LA.eigh(F, S)  # C† S C = I by construction
+
+    X, X_inv = ortho_utils.mo_per_k(S, C)
+
+    # left-inverse
+    assert np.allclose(X @ X_inv, np.eye(n), atol=_TOL)
+    # X F X† is diagonal with mo_energy
+    F_MO = X @ F @ X.conj().T
+    assert np.allclose(F_MO, np.diag(np.diag(F_MO)), atol=_TOL)
+    assert np.allclose(np.sort(np.diag(F_MO).real), np.sort(eps), atol=_TOL)
+    # X S X† = I
+    S_MO = X @ S @ X.conj().T
+    assert np.allclose(S_MO, np.eye(n), atol=_TOL)
+
+
+def test_natural_per_k_diagonalizes_dm(rng):
+    n = 6
+    S = _hermitian_pd(rng, n)
+    # construct a positive-semi-definite "density" matrix
+    B = rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n))
+    dm = B.conj().T @ B
+    dm = 0.5 * (dm + dm.conj().T)
+
+    X, X_inv = ortho_utils.natural_per_k(S, dm)
+
+    # left-inverse
+    assert np.allclose(X @ X_inv, np.eye(n), atol=_TOL)
+    # X_inv dm X_inv†  is diagonal (NO occupations on diagonal)
+    D = X_inv @ dm @ X_inv.conj().T
+    assert np.allclose(D, np.diag(np.diag(D)), atol=_TOL)
+    # the eigh(dm, S^{-1}) formulation gives V s.t. V† S^{-1} V = I,
+    # i.e. X_inv @ inv(S) @ X_inv† = I  (not X S X†)
+    S_inv = np.linalg.inv(S)
+    assert np.allclose(X_inv @ S_inv @ X_inv.conj().T, np.eye(n), atol=_TOL)
+
+
+def test_helpers_return_complex128(rng):
+    n = 3
+    S = _hermitian_pd(rng, n)
+    F = _hermitian(rng, n)
+    _, C = LA.eigh(F, S)
+    dm = _hermitian_pd(rng, n, shift=0.0)
+
+    for X, X_inv in (
+        ortho_utils.lowdin_per_k(S),
+        ortho_utils.mo_per_k(S, C),
+        ortho_utils.natural_per_k(S, dm),
+    ):
+        assert X.dtype == np.complex128
+        assert X_inv.dtype == np.complex128


### PR DESCRIPTION
## Summary

Five coordinated changes (one commit each) that overhaul the orthogonalization layer end-to-end:

1. **`feat(ortho_utils)`** — new full-BZ orthogonalization built only at IBZ k-points and propagated to every star member via the same `kstruct` / `KPoints` object the rest of mbtools uses (`get_representation`, `get_spinor_representation`, `bz2ibz`, `ibz2bz`, `stars_ops_bz`, `time_reversal_symm_bz`). Replaces the inversion+TR-only `O(N_k²)` `-k` pairing loop and the per-k `eigh` phase ambiguity. Exposes two public entry points: `build_X_kspace(mode, kstruct, mycell, S_ibz, ...)` and `build_X_kspace_from_ao_reps(mode, S_ibz, ibz2bz, bz2ibz, k_sym_transform_ao, *, tr_conj, ...)` for callers that consume the symmetry arrays directly from `input.h5`.

2. **`feat(integrals)`** — when `args.orth != "none"`, three-center Coulomb integrals (`df_int`, `df_hf_int`) and the GF2 Ewald correction (`df_ewald.h5`) are now rotated to the same basis as `S` / `F` / `T` / `dm` in `input.h5`. Previously V stayed AO-basis when S/F/T were ortho — downstream consumers either had to re-apply X themselves or silently mixed bases.

3. **`refactor(seet_init)`** — `seet_init.get_input_data()` return tuple shrunk from 15 entries to 7 (`F, S, T, dm, dm_s, kmesh, kmesh_sc`). The dropped entries were write-only at the single caller. **Breaking change** — paired with the green-mbpt PR.

4. **`fix(ortho_utils)`** — natural-mode orthogonalization now diagonalises `S^{-1/2}·dm·S^{-1/2}` and returns S-orthonormal natural orbitals `(X = C_NO†, X_inv = S·C_NO)` matching `mo_per_k`'s shape contract. The previous `eigh(dm, S^{-1})` form gave S⁻¹-orthonormal orbitals that didn't orthogonalise S, blowing up the initial chemical potential and one-body energy by orders of magnitude (verified on H2 / cc-pvdz: e_1b was −86 Ha pre-fix, −2.5 Ha after).

5. **`chore(ortho_utils)`** — drops the legacy inversion+TR-only entry points (`symmetrical_orbitals`, `canonical_orbitals`, `natural_orbitals`) and their helpers (`wrap_k`, `normalize`, `avg`) — superseded by the kspace layer. Adds `symmetric_lowdin_per_k` for the Hermitian X = S^{−½} variant (distinct from `lowdin_per_k`'s canonical V·Λ^{−½} form); wired into `_build_X_ibz` as mode `\"symmetric_lowdin\"`. The spinor path now accepts both Löwdin variants.

## Coordination

This PR pairs with **green-mbpt#TBD** which updates `python/init_seet.py` to consume the new `build_X_kspace_from_ao_reps` API and the trimmed `get_input_data()` return tuple. Merge order: this PR first, then the green-mbpt PR.

## Backward compatibility

This is a major-version-style change with several breaks:
- Legacy ortho_utils entry points removed (replaced by `build_X_kspace_from_ao_reps`).
- `seet_init.get_input_data()` return shape changed (one caller, updated in lockstep).
- Older `input.h5` files lacking `symmetry/k/k_sym_transform_ao` need to be regenerated by the current mean-field driver.
- `args.orth = \"none\"` (the default) is a literal no-op — no behavior or byte changes when the new feature isn't requested.

## Test plan

- [x] `tests/ortho_utils_test.py` + `tests/ortho_utils_kspace_test.py`: 19 passed, 1 skipped.
- [x] H2 / cc-pvdz manual end-to-end via `mbpt.exe --scf_type {HF, GW, GF2}` for `--orth {none, lowdin, mo, natural}`: all four modes give the same converged total energy to machine precision (∼1e-15).
- [x] C++ orth basis-invariance SECTIONs in green-mbpt's `solvers_test`: all 27 REQUIREs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)