### PR TITLE
chore: prep 1.0.0a0 release

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  release:
+    types: [published]
 
 jobs:
   build_wheels:
@@ -77,9 +79,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    #if: github.event_name == 'release' && github.event.action == 'published'
-    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/green_mbtools/version.py
+++ b/green_mbtools/version.py
@@ -1,2 +1,2 @@
 # Version for Green-MBTools Package
-__version__ = "1.0.0"
+__version__ = "1.0.0a0"


### PR DESCRIPTION
## Summary
- Bump \`__version__\` to PEP 440 alpha \`1.0.0a0\` (canonical form; pip normalizes \`1.0.0-alpha\` → \`1.0.0a0\` anyway).
- Add \`release: [published]\` trigger to the wheels workflow.
- Gate \`upload_pypi\` on release events only; master pushes and PRs still build wheels (catches build regressions) but do not upload to PyPI.

Prep for the v1.0.0a0 release.

## Test plan
- [ ] CI builds wheels on this PR (sanity check the new \`on:\` block parses).
- [ ] After merge, drafting a GitHub release with tag \`v1.0.0a0\` fires the workflow and \`upload_pypi\` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)