### PR TITLE
Einsum optimization + Python 3.13/3.14 support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_ARCHS: ${{ matrix.plat.arch }}
           CIBW_ENVIRONMENT: >
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.plat.target }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.4.1
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
           CIBW_ARCHS: ${{ matrix.plat.arch }}
           CIBW_ENVIRONMENT: >
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.plat.target }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.13
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/green_mbtools/pesto/mb.py
+++ b/green_mbtools/pesto/mb.py
@@ -313,7 +313,7 @@ class MB_post(object):
         occupations = np.zeros((self._ns, orbitals.shape[0]), dtype=complex)
         if self.S is not None:
             occupations = np.einsum(
-                'k,skij,skji->si', self._weight_ibz, self.dm, self.S
+                'k,skij,skji->si', self._weight_ibz, self.dm, self.S, optimize=True
             )
         else:
             occupations = np.einsum('k,skii->si', self._weight_ibz, self.dm)
@@ -382,7 +382,7 @@ class MB_post(object):
             gtau_orth = orth.sao_orth(
                 self.gtau, self.S, type='g'
             ) if self.S is not None else self.gtau
-            gtau_inp = np.einsum("...ii->...i", gtau_orth)
+            gtau_inp = np.diagonal(gtau_orth, axis1=-2, axis2=-1)
         else:
             gtau_inp = gtau_orth
         tau_mesh = self.ir.tau_mesh
@@ -418,7 +418,7 @@ class MB_post(object):
             gtau_orth = orth.sao_orth(
                 self.gtau, self.S, type='g'
             ) if self.S is not None else self.gtau
-            gtau_orth = np.einsum("...ii->...i", gtau_orth)
+            gtau_orth = np.diagonal(gtau_orth, axis1=-2, axis2=-1)
         nw = self.ir.wsample.shape[0]
         Gw_inp = self.ir.tau_to_w(gtau_orth)[nw//2:]
 
@@ -472,13 +472,13 @@ def to_full_bz(X, conj_list, ibz2bz, bz2ibz, k_ind, k_sym_trans):
             Xk = X[:, k, ::].conj() if conj_list[ik] else X[:, k, ::]
             Uk = k_sym_trans[ik]
             Uk_dag = Uk.conj().T
-            Xk = np.einsum('ab,sbc,cd->sad', Uk, Xk, Uk_dag)
+            Xk = (Uk @ Xk) @ Uk_dag
             Y[:, ik, ::] = Xk
         elif k_ind == 2:
             Xk = X[:, :, k, ::].conj() if conj_list[ik] else X[:, :, k, ::]
             Uk = k_sym_trans[ik]
             Uk_dag = Uk.conj().T
-            Xk = np.einsum('ab,tsbc,cd->tsad', Uk, Xk, Uk_dag)
+            Xk = (Uk @ Xk) @ Uk_dag
             Y[:, :, ik, ::] = Xk
     return Y
 

--- a/green_mbtools/version.py
+++ b/green_mbtools/version.py
@@ -1,2 +1,2 @@
 # Version for Green-MBTools Package
-__version__ = "1.0.0a0"
+__version__ = "1.0.0a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = ["numpy", "ase", "spglib", "numba", "pyscf", "scipy", "h5py", "gr
 
 description = "Collection of Python tools for quantum many-body simulation using Green Software Package"
 readme = "README.md"
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = ["numpy", "ase", "spglib", "numba", "pyscf", "scipy", "h5py", "gr
 
 description = "Collection of Python tools for quantum many-body simulation using Green Software Package"
 readme = "README.md"
-requires-python = ">=3.8,<3.14"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR started as an einsum optimization and grew into a small maintenance batch. Changes:

* **Optimize expensive `numpy.einsum` calls** in `mb.py` — add `optimize=True`, which otherwise makes these contractions too slow.
* **Bump supported Python version to 3.13** in `pyproject.toml` and the build/test workflows.
* **Add Python 3.14 support**:
  * Build cp314 wheels by bumping cibuildwheel to v3.4.1, which ships CPython 3.14 as a stable default target (v2.21.3 cannot build cp314).
  * Drop the `requires-python` upper bound (now just `>=3.8`). A speculative cap blocks installation on newer Python versions even when the code works there, and pip then silently falls back to an older release. The real ceiling is enforced by dependencies (e.g. numba) anyway, so we cap only on a demonstrated incompatibility.
* **Introduce a new pre-release** (`1.0.0a1`) tested and supported on Python 3.13/3.14.