### PR TITLE
ci: parallelize wheel builds across the Python matrix

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -10,14 +10,29 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.plat.os }}
-    runs-on: ${{ matrix.plat.os }}
+    name: Build ${{ matrix.build }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        # macos-14 GitHub runner (Apple Silicon / arm64)
-        plat: 
-        - { os: ubuntu-22.04, target: "", arch: x86_64}
-        - { os: macos-14, target: "14.0" , arch: arm64}
+        # Each entry is a separate parallel job. Interpreters are grouped so
+        # the job count matches the free-tier concurrency we actually get:
+        #   - macOS (arm64): 5 jobs == free-tier macOS concurrency cap, so
+        #     nothing queues behind the limit (and re-pays brew setup).
+        #   - Linux (x86_64): cheap 1x runners, one interpreter each.
+        include:
+          - { os: macos-14, arch: arm64, target: "14.0", build: "cp38-* cp39-*" }
+          - { os: macos-14, arch: arm64, target: "14.0", build: "cp310-* cp311-*" }
+          - { os: macos-14, arch: arm64, target: "14.0", build: "cp312-*" }
+          - { os: macos-14, arch: arm64, target: "14.0", build: "cp313-*" }
+          - { os: macos-14, arch: arm64, target: "14.0", build: "cp314-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp38-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp39-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp310-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp311-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp312-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp313-*" }
+          - { os: ubuntu-22.04, arch: x86_64, target: "", build: "cp314-*" }
 
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +40,10 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
-          CIBW_ARCHS: ${{ matrix.plat.arch }}
+          CIBW_BUILD: ${{ matrix.build }}
+          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT: >
-            MACOSX_DEPLOYMENT_TARGET=${{ matrix.plat.target }}
+            MACOSX_DEPLOYMENT_TARGET=${{ matrix.target }}
             OPENBLAS_NUM_THREADS=1
             OMP_NUM_THREADS=1
             MKL_NUM_THREADS=1
@@ -54,7 +69,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.plat.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
 


### PR DESCRIPTION
## What

Splits wheel building from **2 serial jobs** (one per OS, each building `cp38`…`cp314` in sequence) into a **matrix of 12 grouped jobs** so interpreters build in parallel.

## Distribution (sized to free-tier concurrency)

- **macOS (arm64): 5 jobs** — matches the free-tier macOS concurrency cap, so nothing queues behind the limit only to re-pay the slow `brew install openblas hdf5` setup. The 7 interpreters are grouped (two jobs build two each) via `CIBW_BUILD`, which accepts a space-separated list.
- **Linux (x86_64): 7 jobs** — one interpreter each; cheap 1× runners that all fit under the total concurrency cap.

## Details

- Flattened `matrix.plat.*` → `matrix.os/arch/target` for the `include`-style matrix.
- Added `fail-fast: false` so one interpreter failing doesn't cancel the rest.
- Artifact name stays keyed on `strategy.job-index` (unique across all jobs; `matrix.build` can't be used — it contains `*`, which is illegal in artifact names). Downstream `upload_pypi` still gathers everything via `pattern: cibw-*` + `merge-multiple: true`, unchanged.

## Tradeoffs (accepted)

- **macOS quota:** the `brew` setup now runs 5× instead of once, and macOS minutes bill at 10× — this trades wall-clock for a steeper monthly-minute drain. Cost is concentrated on macOS; Linux fan-out is ~free.
- **Shared concurrency:** the 5-macOS / 20-total caps are account-wide, so these jobs compete with other CI (tests, docs) and may queue during busy periods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)