### PR TITLE
chore: bump version to 1.0.0a2

### DIFF
--- a/green_mbtools/version.py
+++ b/green_mbtools/version.py
@@ -1,2 +1,2 @@
 # Version for Green-MBTools Package
-__version__ = "1.0.0a1"
+__version__ = "1.0.0a2"


### PR DESCRIPTION
Bumps the package version from `1.0.0a1` to `1.0.0a2`.

## Changes included in this release
Both already merged to `master`; this PR just tags the release with a version bump:

- **ci: parallelize wheel builds across the Python matrix** (#48)
- **fix: k-space symmetry AO Bloch phase evaluated at -k for time-reversal points** (#51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)